### PR TITLE
Add ODOO_MCP_ALLOWED_HOSTS env var for DNS rebinding protection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,3 +85,8 @@ ODOO_API_KEY=your-api-key-here
 # Server port for HTTP transport (optional)
 # Only used when transport is streamable-http
 # ODOO_MCP_PORT=8000
+
+# Allowed Host headers for HTTP transport DNS-rebinding protection (optional)
+# Comma-separated; set when running streamable-http behind a reverse proxy
+# that forwards an external host. Unset = no host validation.
+# ODOO_MCP_ALLOWED_HOSTS=odoo.example.com,localhost

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - Unreleased
+
+### Added
+- **`ODOO_MCP_ALLOWED_HOSTS`**: comma-separated `Host` headers to accept for the `streamable-http` transport (DNS-rebinding protection). Needed when running behind a reverse proxy that forwards an external host; unset preserves the prior default (no host validation) (#45, @Miriup).
+
 ## [0.7.0] - 2026-06-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ The server requires the following environment variables:
 | `ODOO_MCP_TRANSPORT` | `stdio` | Transport type (`stdio`, `streamable-http`) |
 | `ODOO_MCP_HOST` | `localhost` | Host to bind for HTTP transport |
 | `ODOO_MCP_PORT` | `8000` | Port to bind for HTTP transport |
+| `ODOO_MCP_ALLOWED_HOSTS` | — | Comma-separated `Host` headers to accept for HTTP transport (DNS-rebinding protection). Set when running `streamable-http` behind a reverse proxy that forwards an external host, e.g. `odoo.example.com,localhost`. Unset leaves the default (no host validation). |
 
 ### Transport Options
 

--- a/mcp_server_odoo/__main__.py
+++ b/mcp_server_odoo/__main__.py
@@ -54,6 +54,8 @@ Optional environment variables:
   ODOO_MCP_TRANSPORT       Transport type: stdio or streamable-http (default: stdio)
   ODOO_MCP_HOST            Server host for HTTP transports (default: localhost)
   ODOO_MCP_PORT            Server port for HTTP transports (default: 8000)
+  ODOO_MCP_ALLOWED_HOSTS   Comma-separated list of allowed Host headers for
+                           DNS rebinding protection (e.g., odoo.example.com,localhost)
 
 For more information, visit: https://github.com/ivnvxd/mcp-server-odoo""",
     )

--- a/mcp_server_odoo/__main__.py
+++ b/mcp_server_odoo/__main__.py
@@ -55,6 +55,8 @@ Optional environment variables:
   ODOO_MCP_HOST            Server host for HTTP transports (default: localhost)
   ODOO_MCP_PORT            Server port for HTTP transports (default: 8000)
   ODOO_MCP_ENABLE_METHOD_CALLS  Enable call_model_method tool, requires ODOO_YOLO=true (default: false)
+  ODOO_MCP_ALLOWED_HOSTS   Comma-separated list of allowed Host headers for
+                           DNS rebinding protection (e.g., odoo.example.com,localhost)
 
 For more information, visit: https://github.com/ivnvxd/mcp-server-odoo""",
     )

--- a/mcp_server_odoo/config.py
+++ b/mcp_server_odoo/config.py
@@ -5,7 +5,7 @@ for connecting to Odoo via XML-RPC.
 """
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Literal, Optional
 
@@ -39,6 +39,9 @@ class OdooConfig:
 
     # YOLO mode configuration
     yolo_mode: str = "off"  # "off", "read", or "true"
+
+    # Allowed hosts for DNS rebinding protection (HTTP transport)
+    allowed_hosts: list[str] = field(default_factory=list)
 
     def __post_init__(self):
         """Validate configuration after initialization."""
@@ -218,6 +221,13 @@ def load_config(env_file: Optional[Path] = None) -> OdooConfig:
             # Invalid value - will be caught by validation
             return yolo_env
 
+    # Helper function to parse allowed hosts
+    def parse_allowed_hosts() -> list[str]:
+        hosts = os.getenv("ODOO_MCP_ALLOWED_HOSTS", "").strip()
+        if not hosts:
+            return []
+        return [h.strip() for h in hosts.split(",") if h.strip()]
+
     # Create configuration
     config = OdooConfig(
         url=os.getenv("ODOO_URL", "").strip(),
@@ -234,6 +244,7 @@ def load_config(env_file: Optional[Path] = None) -> OdooConfig:
         port=get_int_env("ODOO_MCP_PORT", 8000),
         locale=os.getenv("ODOO_LOCALE", "").strip() or None,
         yolo_mode=get_yolo_mode(),
+        allowed_hosts=parse_allowed_hosts(),
     )
 
     return config

--- a/mcp_server_odoo/config.py
+++ b/mcp_server_odoo/config.py
@@ -6,7 +6,7 @@ for connecting to Odoo via XML-RPC.
 
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Literal, Optional
 
@@ -45,6 +45,9 @@ class OdooConfig:
 
     # Opt-in for call_model_method (effective only with yolo_mode == "true").
     enable_method_calls: bool = False
+
+    # Allowed hosts for DNS rebinding protection (HTTP transport)
+    allowed_hosts: list[str] = field(default_factory=list)
 
     def __post_init__(self):
         """Validate configuration after initialization."""
@@ -238,6 +241,13 @@ def load_config(env_file: Optional[Path] = None) -> OdooConfig:
             # Invalid value - will be caught by validation
             return yolo_env
 
+    # Helper function to parse allowed hosts
+    def parse_allowed_hosts() -> list[str]:
+        hosts = os.getenv("ODOO_MCP_ALLOWED_HOSTS", "").strip()
+        if not hosts:
+            return []
+        return [h.strip() for h in hosts.split(",") if h.strip()]
+
     # Create configuration
     config = OdooConfig(
         url=os.getenv("ODOO_URL", "").strip(),
@@ -255,6 +265,7 @@ def load_config(env_file: Optional[Path] = None) -> OdooConfig:
         locale=os.getenv("ODOO_LOCALE", "").strip() or None,
         yolo_mode=get_yolo_mode(),
         enable_method_calls=get_bool_env("ODOO_MCP_ENABLE_METHOD_CALLS", False),
+        allowed_hosts=parse_allowed_hosts(),
     )
 
     return config

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -62,9 +62,7 @@ class OdooMCPServer:
         transport_security = None
         if self.config.allowed_hosts:
             # Build allowed_hosts with wildcard ports
-            allowed_hosts = [
-                f"{h}:*" if ":" not in h else h for h in self.config.allowed_hosts
-            ]
+            allowed_hosts = [f"{h}:*" if ":" not in h else h for h in self.config.allowed_hosts]
             # Build allowed_origins from hosts
             allowed_origins = []
             for h in self.config.allowed_hosts:

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -8,6 +8,7 @@ import contextlib
 from typing import Any, Dict, Optional
 
 from mcp.server import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 
 from .access_control import AccessController
 from .config import OdooConfig, get_config
@@ -57,11 +58,32 @@ class OdooMCPServer:
         self.resource_handler = None
         self.tool_handler = None
 
+        # Configure transport security for DNS rebinding protection
+        transport_security = None
+        if self.config.allowed_hosts:
+            # Build allowed_hosts with wildcard ports
+            allowed_hosts = [
+                f"{h}:*" if ":" not in h else h for h in self.config.allowed_hosts
+            ]
+            # Build allowed_origins from hosts
+            allowed_origins = []
+            for h in self.config.allowed_hosts:
+                base = h.split(":")[0] if ":" in h else h
+                allowed_origins.extend([f"http://{base}:*", f"https://{base}:*"])
+
+            transport_security = TransportSecuritySettings(
+                enable_dns_rebinding_protection=True,
+                allowed_hosts=allowed_hosts,
+                allowed_origins=allowed_origins,
+            )
+
         # Create FastMCP instance with server metadata
         self.app = FastMCP(
             name="odoo-mcp-server",
             instructions="MCP server for accessing and managing Odoo ERP data through the Model Context Protocol",
             lifespan=self._odoo_lifespan,
+            host=self.config.host,
+            transport_security=transport_security,
         )
 
         @self.app.custom_route("/health", methods=["GET"])

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -9,6 +9,7 @@ import contextlib
 from typing import Any, Dict, Optional
 
 from mcp.server import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 
 from . import __version__
 from .access_control import AccessController
@@ -63,11 +64,19 @@ class OdooMCPServer:
         # entries (streamable-http enters the lifespan per session)
         self._connect_lock = asyncio.Lock()
 
+        # Configure transport security for DNS rebinding protection. Left as
+        # None (no allowed_hosts configured) the SDK middleware defaults to
+        # protection DISABLED — preserving prior behavior for stdio and for
+        # HTTP deployments that don't set ODOO_MCP_ALLOWED_HOSTS.
+        transport_security = self._build_transport_security()
+
         # Create FastMCP instance with server metadata
         self.app = FastMCP(
             name="odoo-mcp-server",
             instructions="MCP server for accessing and managing Odoo ERP data through the Model Context Protocol",
             lifespan=self._odoo_lifespan,
+            host=self.config.host,
+            transport_security=transport_security,
         )
 
         @self.app.custom_route("/health", methods=["GET"])
@@ -288,6 +297,31 @@ class OdooMCPServer:
         except Exception as e:
             context = ErrorContext(operation="server_run_http")
             error_handler.handle_error(e, context=context)
+
+    def _build_transport_security(self) -> Optional[TransportSecuritySettings]:
+        """Build DNS-rebinding-protection settings from ODOO_MCP_ALLOWED_HOSTS.
+
+        Returns None when no hosts are configured, which leaves the SDK
+        middleware at its default (protection disabled) — unchanged behavior
+        for stdio and for HTTP deployments behind a proxy that don't set the
+        variable. When hosts are configured, each is allowed on any port and
+        matching http/https origins are derived.
+        """
+        if not self.config.allowed_hosts:
+            return None
+
+        allowed_hosts: list[str] = []
+        allowed_origins: list[str] = []
+        for host in self.config.allowed_hosts:
+            base = host.split(":")[0] if ":" in host else host
+            allowed_hosts.append(host if ":" in host else f"{host}:*")
+            allowed_origins.extend([f"http://{base}:*", f"https://{base}:*"])
+
+        return TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=allowed_hosts,
+            allowed_origins=allowed_origins,
+        )
 
     def _warn_if_exposed(self, host: str) -> None:
         """Warn loudly when the HTTP transport binds a non-loopback host.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -400,3 +400,91 @@ class TestYoloMode:
             monkeypatch.setenv("ODOO_YOLO", value)
             config = load_config()
             assert config.yolo_mode == "true"
+
+
+class TestAllowedHosts:
+    """Test allowed hosts configuration for DNS rebinding protection."""
+
+    def test_allowed_hosts_default_empty(self):
+        """Test allowed_hosts defaults to empty list."""
+        config = OdooConfig(url="http://localhost:8069", api_key="test")
+        assert config.allowed_hosts == []
+
+    def test_allowed_hosts_set_directly(self):
+        """Test allowed_hosts can be set directly."""
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test",
+            allowed_hosts=["localhost", "example.com"],
+        )
+        assert config.allowed_hosts == ["localhost", "example.com"]
+
+    def test_allowed_hosts_from_env_single(self, monkeypatch):
+        """Test loading single allowed host from environment."""
+        monkeypatch.setenv("ODOO_URL", "http://localhost:8069")
+        monkeypatch.setenv("ODOO_API_KEY", "test-key")
+        monkeypatch.setenv("ODOO_MCP_ALLOWED_HOSTS", "localhost")
+
+        config = load_config()
+
+        assert config.allowed_hosts == ["localhost"]
+
+    def test_allowed_hosts_from_env_multiple(self, monkeypatch):
+        """Test loading multiple allowed hosts from environment."""
+        monkeypatch.setenv("ODOO_URL", "http://localhost:8069")
+        monkeypatch.setenv("ODOO_API_KEY", "test-key")
+        monkeypatch.setenv("ODOO_MCP_ALLOWED_HOSTS", "localhost,example.com,odoo.local")
+
+        config = load_config()
+
+        assert config.allowed_hosts == ["localhost", "example.com", "odoo.local"]
+
+    def test_allowed_hosts_from_env_with_whitespace(self, monkeypatch):
+        """Test that whitespace is trimmed from allowed hosts."""
+        monkeypatch.setenv("ODOO_URL", "http://localhost:8069")
+        monkeypatch.setenv("ODOO_API_KEY", "test-key")
+        monkeypatch.setenv("ODOO_MCP_ALLOWED_HOSTS", " localhost , example.com , odoo.local ")
+
+        config = load_config()
+
+        assert config.allowed_hosts == ["localhost", "example.com", "odoo.local"]
+
+    def test_allowed_hosts_from_env_empty_string(self, monkeypatch):
+        """Test that empty string results in empty list."""
+        monkeypatch.setenv("ODOO_URL", "http://localhost:8069")
+        monkeypatch.setenv("ODOO_API_KEY", "test-key")
+        monkeypatch.setenv("ODOO_MCP_ALLOWED_HOSTS", "")
+
+        config = load_config()
+
+        assert config.allowed_hosts == []
+
+    def test_allowed_hosts_from_env_whitespace_only(self, monkeypatch):
+        """Test that whitespace-only string results in empty list."""
+        monkeypatch.setenv("ODOO_URL", "http://localhost:8069")
+        monkeypatch.setenv("ODOO_API_KEY", "test-key")
+        monkeypatch.setenv("ODOO_MCP_ALLOWED_HOSTS", "   ")
+
+        config = load_config()
+
+        assert config.allowed_hosts == []
+
+    def test_allowed_hosts_skips_empty_entries(self, monkeypatch):
+        """Test that empty entries between commas are skipped."""
+        monkeypatch.setenv("ODOO_URL", "http://localhost:8069")
+        monkeypatch.setenv("ODOO_API_KEY", "test-key")
+        monkeypatch.setenv("ODOO_MCP_ALLOWED_HOSTS", "localhost,,example.com,  ,odoo.local")
+
+        config = load_config()
+
+        assert config.allowed_hosts == ["localhost", "example.com", "odoo.local"]
+
+    def test_allowed_hosts_with_ports(self, monkeypatch):
+        """Test allowed hosts can include port numbers."""
+        monkeypatch.setenv("ODOO_URL", "http://localhost:8069")
+        monkeypatch.setenv("ODOO_API_KEY", "test-key")
+        monkeypatch.setenv("ODOO_MCP_ALLOWED_HOSTS", "localhost:8000,example.com:443")
+
+        config = load_config()
+
+        assert config.allowed_hosts == ["localhost:8000", "example.com:443"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -461,3 +461,91 @@ class TestEnableMethodCalls:
         assert not any(
             "ODOO_MCP_ENABLE_METHOD_CALLS=true ignored" in r.message for r in caplog.records
         )
+
+
+class TestAllowedHosts:
+    """Test allowed hosts configuration for DNS rebinding protection."""
+
+    def test_allowed_hosts_default_empty(self):
+        """Test allowed_hosts defaults to empty list."""
+        config = OdooConfig(url="http://localhost:8069", api_key="test")
+        assert config.allowed_hosts == []
+
+    def test_allowed_hosts_set_directly(self):
+        """Test allowed_hosts can be set directly."""
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test",
+            allowed_hosts=["localhost", "example.com"],
+        )
+        assert config.allowed_hosts == ["localhost", "example.com"]
+
+    def test_allowed_hosts_from_env_single(self, monkeypatch):
+        """Test loading single allowed host from environment."""
+        monkeypatch.setenv("ODOO_URL", "http://localhost:8069")
+        monkeypatch.setenv("ODOO_API_KEY", "test-key")
+        monkeypatch.setenv("ODOO_MCP_ALLOWED_HOSTS", "localhost")
+
+        config = load_config()
+
+        assert config.allowed_hosts == ["localhost"]
+
+    def test_allowed_hosts_from_env_multiple(self, monkeypatch):
+        """Test loading multiple allowed hosts from environment."""
+        monkeypatch.setenv("ODOO_URL", "http://localhost:8069")
+        monkeypatch.setenv("ODOO_API_KEY", "test-key")
+        monkeypatch.setenv("ODOO_MCP_ALLOWED_HOSTS", "localhost,example.com,odoo.local")
+
+        config = load_config()
+
+        assert config.allowed_hosts == ["localhost", "example.com", "odoo.local"]
+
+    def test_allowed_hosts_from_env_with_whitespace(self, monkeypatch):
+        """Test that whitespace is trimmed from allowed hosts."""
+        monkeypatch.setenv("ODOO_URL", "http://localhost:8069")
+        monkeypatch.setenv("ODOO_API_KEY", "test-key")
+        monkeypatch.setenv("ODOO_MCP_ALLOWED_HOSTS", " localhost , example.com , odoo.local ")
+
+        config = load_config()
+
+        assert config.allowed_hosts == ["localhost", "example.com", "odoo.local"]
+
+    def test_allowed_hosts_from_env_empty_string(self, monkeypatch):
+        """Test that empty string results in empty list."""
+        monkeypatch.setenv("ODOO_URL", "http://localhost:8069")
+        monkeypatch.setenv("ODOO_API_KEY", "test-key")
+        monkeypatch.setenv("ODOO_MCP_ALLOWED_HOSTS", "")
+
+        config = load_config()
+
+        assert config.allowed_hosts == []
+
+    def test_allowed_hosts_from_env_whitespace_only(self, monkeypatch):
+        """Test that whitespace-only string results in empty list."""
+        monkeypatch.setenv("ODOO_URL", "http://localhost:8069")
+        monkeypatch.setenv("ODOO_API_KEY", "test-key")
+        monkeypatch.setenv("ODOO_MCP_ALLOWED_HOSTS", "   ")
+
+        config = load_config()
+
+        assert config.allowed_hosts == []
+
+    def test_allowed_hosts_skips_empty_entries(self, monkeypatch):
+        """Test that empty entries between commas are skipped."""
+        monkeypatch.setenv("ODOO_URL", "http://localhost:8069")
+        monkeypatch.setenv("ODOO_API_KEY", "test-key")
+        monkeypatch.setenv("ODOO_MCP_ALLOWED_HOSTS", "localhost,,example.com,  ,odoo.local")
+
+        config = load_config()
+
+        assert config.allowed_hosts == ["localhost", "example.com", "odoo.local"]
+
+    def test_allowed_hosts_with_ports(self, monkeypatch):
+        """Test allowed hosts can include port numbers."""
+        monkeypatch.setenv("ODOO_URL", "http://localhost:8069")
+        monkeypatch.setenv("ODOO_API_KEY", "test-key")
+        monkeypatch.setenv("ODOO_MCP_ALLOWED_HOSTS", "localhost:8000,example.com:443")
+
+        config = load_config()
+
+        assert config.allowed_hosts == ["localhost:8000", "example.com:443"]

--- a/tests/test_server_foundation.py
+++ b/tests/test_server_foundation.py
@@ -679,3 +679,123 @@ class TestFastMCPApp:
             health = server.get_health_status()
             assert health["status"] == "healthy"
             assert health["connection"]["connected"] is True
+
+
+class TestTransportSecurity:
+    """Test transport security configuration for DNS rebinding protection."""
+
+    def test_no_transport_security_by_default(self):
+        """Test that no transport security is configured when allowed_hosts is empty."""
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_api_key",
+            allowed_hosts=[],
+        )
+        server = OdooMCPServer(config)
+
+        # FastMCP should not have transport_security set
+        # We check via the settings or internal state
+        assert server.app.settings.host == "localhost"
+
+    def test_transport_security_with_single_host(self):
+        """Test transport security is configured with a single allowed host."""
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_api_key",
+            allowed_hosts=["localhost"],
+        )
+        server = OdooMCPServer(config)
+
+        # Server should be created successfully with transport security
+        assert server.app is not None
+        assert server.config.allowed_hosts == ["localhost"]
+
+    def test_transport_security_with_multiple_hosts(self):
+        """Test transport security with multiple allowed hosts."""
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_api_key",
+            allowed_hosts=["localhost", "example.com", "odoo.local"],
+        )
+        server = OdooMCPServer(config)
+
+        assert server.app is not None
+        assert len(server.config.allowed_hosts) == 3
+
+    def test_transport_security_host_with_port_preserved(self):
+        """Test that hosts with ports are preserved as-is."""
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_api_key",
+            allowed_hosts=["localhost:8000", "example.com"],
+        )
+        server = OdooMCPServer(config)
+
+        # The server should handle both formats
+        assert "localhost:8000" in server.config.allowed_hosts
+        assert "example.com" in server.config.allowed_hosts
+
+    def test_transport_security_builds_allowed_origins(self):
+        """Test that allowed_origins are built from allowed_hosts."""
+        from mcp.server.transport_security import TransportSecuritySettings
+
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_api_key",
+            allowed_hosts=["example.com"],
+        )
+
+        # Capture the TransportSecuritySettings that would be created
+        with patch.object(
+            TransportSecuritySettings, "__init__", return_value=None
+        ) as mock_init:
+            # Create server - this will call TransportSecuritySettings
+            server = OdooMCPServer(config)
+
+            # Verify TransportSecuritySettings was called with correct params
+            mock_init.assert_called_once()
+            call_kwargs = mock_init.call_args[1]
+
+            assert call_kwargs["enable_dns_rebinding_protection"] is True
+            assert "example.com:*" in call_kwargs["allowed_hosts"]
+            assert "http://example.com:*" in call_kwargs["allowed_origins"]
+            assert "https://example.com:*" in call_kwargs["allowed_origins"]
+
+    def test_transport_security_host_with_port_extracts_base(self):
+        """Test that base hostname is extracted from host:port for origins."""
+        from mcp.server.transport_security import TransportSecuritySettings
+
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_api_key",
+            allowed_hosts=["example.com:8080"],
+        )
+
+        with patch.object(
+            TransportSecuritySettings, "__init__", return_value=None
+        ) as mock_init:
+            server = OdooMCPServer(config)
+
+            call_kwargs = mock_init.call_args[1]
+
+            # Host with port should be preserved as-is (already has port)
+            assert "example.com:8080" in call_kwargs["allowed_hosts"]
+            # Origins should use base hostname with wildcard port
+            assert "http://example.com:*" in call_kwargs["allowed_origins"]
+            assert "https://example.com:*" in call_kwargs["allowed_origins"]
+
+    def test_transport_security_not_configured_when_empty(self):
+        """Test we pass None as transport_security when allowed_hosts is empty."""
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_api_key",
+            allowed_hosts=[],
+        )
+
+        with patch("mcp_server_odoo.server.FastMCP") as mock_fastmcp:
+            mock_fastmcp.return_value = Mock()
+            server = OdooMCPServer(config)
+
+            # Verify FastMCP was called with transport_security=None
+            call_kwargs = mock_fastmcp.call_args[1]
+            assert call_kwargs.get("transport_security") is None

--- a/tests/test_server_foundation.py
+++ b/tests/test_server_foundation.py
@@ -746,11 +746,9 @@ class TestTransportSecurity:
         )
 
         # Capture the TransportSecuritySettings that would be created
-        with patch.object(
-            TransportSecuritySettings, "__init__", return_value=None
-        ) as mock_init:
+        with patch.object(TransportSecuritySettings, "__init__", return_value=None) as mock_init:
             # Create server - this will call TransportSecuritySettings
-            server = OdooMCPServer(config)
+            OdooMCPServer(config)
 
             # Verify TransportSecuritySettings was called with correct params
             mock_init.assert_called_once()
@@ -771,10 +769,8 @@ class TestTransportSecurity:
             allowed_hosts=["example.com:8080"],
         )
 
-        with patch.object(
-            TransportSecuritySettings, "__init__", return_value=None
-        ) as mock_init:
-            server = OdooMCPServer(config)
+        with patch.object(TransportSecuritySettings, "__init__", return_value=None) as mock_init:
+            OdooMCPServer(config)
 
             call_kwargs = mock_init.call_args[1]
 
@@ -794,7 +790,7 @@ class TestTransportSecurity:
 
         with patch("mcp_server_odoo.server.FastMCP") as mock_fastmcp:
             mock_fastmcp.return_value = Mock()
-            server = OdooMCPServer(config)
+            OdooMCPServer(config)
 
             # Verify FastMCP was called with transport_security=None
             call_kwargs = mock_fastmcp.call_args[1]

--- a/tests/test_server_foundation.py
+++ b/tests/test_server_foundation.py
@@ -836,3 +836,123 @@ class TestConnectionPersistsAcrossHttpSessions:
         )
         assert reg_res.call_count == 1, "resources must register after recovery"
         assert reg_tools.call_count == 1, "tools must register after recovery"
+
+
+class TestTransportSecurity:
+    """Test transport security configuration for DNS rebinding protection."""
+
+    def test_no_transport_security_by_default(self):
+        """Test that no transport security is configured when allowed_hosts is empty."""
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_api_key",
+            allowed_hosts=[],
+        )
+        server = OdooMCPServer(config)
+
+        # FastMCP should not have transport_security set
+        # We check via the settings or internal state
+        assert server.app.settings.host == "localhost"
+
+    def test_transport_security_with_single_host(self):
+        """Test transport security is configured with a single allowed host."""
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_api_key",
+            allowed_hosts=["localhost"],
+        )
+        server = OdooMCPServer(config)
+
+        # Server should be created successfully with transport security
+        assert server.app is not None
+        assert server.config.allowed_hosts == ["localhost"]
+
+    def test_transport_security_with_multiple_hosts(self):
+        """Test transport security with multiple allowed hosts."""
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_api_key",
+            allowed_hosts=["localhost", "example.com", "odoo.local"],
+        )
+        server = OdooMCPServer(config)
+
+        assert server.app is not None
+        assert len(server.config.allowed_hosts) == 3
+
+    def test_transport_security_host_with_port_preserved(self):
+        """Test that hosts with ports are preserved as-is."""
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_api_key",
+            allowed_hosts=["localhost:8000", "example.com"],
+        )
+        server = OdooMCPServer(config)
+
+        # The server should handle both formats
+        assert "localhost:8000" in server.config.allowed_hosts
+        assert "example.com" in server.config.allowed_hosts
+
+    def test_transport_security_builds_allowed_origins(self):
+        """Test that allowed_origins are built from allowed_hosts."""
+        from mcp.server.transport_security import TransportSecuritySettings
+
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_api_key",
+            allowed_hosts=["example.com"],
+        )
+
+        # Capture the TransportSecuritySettings that would be created
+        with patch.object(
+            TransportSecuritySettings, "__init__", return_value=None
+        ) as mock_init:
+            # Create server - this will call TransportSecuritySettings
+            server = OdooMCPServer(config)
+
+            # Verify TransportSecuritySettings was called with correct params
+            mock_init.assert_called_once()
+            call_kwargs = mock_init.call_args[1]
+
+            assert call_kwargs["enable_dns_rebinding_protection"] is True
+            assert "example.com:*" in call_kwargs["allowed_hosts"]
+            assert "http://example.com:*" in call_kwargs["allowed_origins"]
+            assert "https://example.com:*" in call_kwargs["allowed_origins"]
+
+    def test_transport_security_host_with_port_extracts_base(self):
+        """Test that base hostname is extracted from host:port for origins."""
+        from mcp.server.transport_security import TransportSecuritySettings
+
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_api_key",
+            allowed_hosts=["example.com:8080"],
+        )
+
+        with patch.object(
+            TransportSecuritySettings, "__init__", return_value=None
+        ) as mock_init:
+            server = OdooMCPServer(config)
+
+            call_kwargs = mock_init.call_args[1]
+
+            # Host with port should be preserved as-is (already has port)
+            assert "example.com:8080" in call_kwargs["allowed_hosts"]
+            # Origins should use base hostname with wildcard port
+            assert "http://example.com:*" in call_kwargs["allowed_origins"]
+            assert "https://example.com:*" in call_kwargs["allowed_origins"]
+
+    def test_transport_security_not_configured_when_empty(self):
+        """Test we pass None as transport_security when allowed_hosts is empty."""
+        config = OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_api_key",
+            allowed_hosts=[],
+        )
+
+        with patch("mcp_server_odoo.server.FastMCP") as mock_fastmcp:
+            mock_fastmcp.return_value = Mock()
+            server = OdooMCPServer(config)
+
+            # Verify FastMCP was called with transport_security=None
+            call_kwargs = mock_fastmcp.call_args[1]
+            assert call_kwargs.get("transport_security") is None

--- a/tests/test_server_foundation.py
+++ b/tests/test_server_foundation.py
@@ -952,3 +952,34 @@ class TestTransportSecurity:
             # Verify FastMCP was called with transport_security=None
             call_kwargs = mock_fastmcp.call_args[1]
             assert call_kwargs.get("transport_security") is None
+
+    def test_build_transport_security_returns_none_without_hosts(self):
+        """Empty allowed_hosts → None, leaving the SDK default (protection off)."""
+        server = OdooMCPServer(
+            OdooConfig(url="http://localhost:8069", api_key="k", allowed_hosts=[])
+        )
+        assert server._build_transport_security() is None
+
+    def test_build_transport_security_settings_shape(self):
+        """Configured hosts produce wildcard-port hosts and http/https origins;
+        a host that already carries a port keeps it verbatim."""
+        server = OdooMCPServer(
+            OdooConfig(
+                url="http://localhost:8069",
+                api_key="k",
+                allowed_hosts=["odoo.example.com", "localhost:9000"],
+            )
+        )
+        settings = server._build_transport_security()
+
+        assert settings is not None
+        assert settings.enable_dns_rebinding_protection is True
+        # bare host gets :*, host:port is preserved as-is
+        assert settings.allowed_hosts == ["odoo.example.com:*", "localhost:9000"]
+        # origins use the base hostname (port stripped) on both schemes
+        assert settings.allowed_origins == [
+            "http://odoo.example.com:*",
+            "https://odoo.example.com:*",
+            "http://localhost:*",
+            "https://localhost:*",
+        ]

--- a/tests/test_server_foundation.py
+++ b/tests/test_server_foundation.py
@@ -903,11 +903,9 @@ class TestTransportSecurity:
         )
 
         # Capture the TransportSecuritySettings that would be created
-        with patch.object(
-            TransportSecuritySettings, "__init__", return_value=None
-        ) as mock_init:
+        with patch.object(TransportSecuritySettings, "__init__", return_value=None) as mock_init:
             # Create server - this will call TransportSecuritySettings
-            server = OdooMCPServer(config)
+            OdooMCPServer(config)
 
             # Verify TransportSecuritySettings was called with correct params
             mock_init.assert_called_once()
@@ -928,10 +926,8 @@ class TestTransportSecurity:
             allowed_hosts=["example.com:8080"],
         )
 
-        with patch.object(
-            TransportSecuritySettings, "__init__", return_value=None
-        ) as mock_init:
-            server = OdooMCPServer(config)
+        with patch.object(TransportSecuritySettings, "__init__", return_value=None) as mock_init:
+            OdooMCPServer(config)
 
             call_kwargs = mock_init.call_args[1]
 
@@ -951,7 +947,7 @@ class TestTransportSecurity:
 
         with patch("mcp_server_odoo.server.FastMCP") as mock_fastmcp:
             mock_fastmcp.return_value = Mock()
-            server = OdooMCPServer(config)
+            OdooMCPServer(config)
 
             # Verify FastMCP was called with transport_security=None
             call_kwargs = mock_fastmcp.call_args[1]


### PR DESCRIPTION
I'm using the `streamable-http` transport with a proxy that adds SSL connectivity, because my odoo runs on localhost. In this setup it I need to be able to configure the `Host` header it should accept. This change makes this possible.

When using `streamable-http` transport, FastMCP auto-enables DNS rebinding protection with only localhost addresses allowed. This causes requests with external Host headers to be rejected with HTTP 421.

Add `ODOO_MCP_ALLOWED_HOSTS` environment variable to explicitly configure allowed hosts. The value is a comma-separated list of hostnames that will be accepted in Host headers (e.g., "odoo.example.com,localhost").

Let me know if it needs any changes and I task Claude Code to do them.