### PR TITLE
fix: HTTP transport loses authentication state after lifespan re-entry

### DIFF
--- a/mcp_server_odoo/resources.py
+++ b/mcp_server_odoo/resources.py
@@ -5,7 +5,7 @@ standardized URIs using FastMCP decorators.
 """
 
 import json
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from urllib.parse import unquote
 
 from mcp.server.fastmcp import Context, FastMCP
@@ -26,6 +26,9 @@ from .uri_schema import (
     build_search_uri,
 )
 
+if TYPE_CHECKING:
+    from .server import OdooMCPServer
+
 logger = get_logger(__name__)
 
 
@@ -35,7 +38,7 @@ class OdooResourceHandler:
     def __init__(
         self,
         app: FastMCP,
-        connection: OdooConnection,
+        server: "OdooMCPServer",
         access_controller: AccessController,
         config: OdooConfig,
     ):
@@ -43,17 +46,33 @@ class OdooResourceHandler:
 
         Args:
             app: FastMCP application instance
-            connection: Odoo connection instance
+            server: OdooMCPServer instance (for dynamic connection access)
             access_controller: Access control instance
             config: Odoo configuration instance
         """
         self.app = app
-        self.connection = connection
+        self._server = server  # Store server reference for dynamic connection access
         self.access_controller = access_controller
         self.config = config
 
         # Register resources
         self._register_resources()
+
+    @property
+    def connection(self) -> OdooConnection:
+        """Get the current connection from the server.
+
+        This property provides dynamic access to the connection,
+        ensuring we always use the current connection even after
+        lifespan re-entry in HTTP transport.
+
+        Raises:
+            ValidationError: If not authenticated with Odoo
+        """
+        conn = self._server.connection
+        if not conn or not conn.is_authenticated:
+            raise ValidationError("Not authenticated with Odoo")
+        return conn
 
     async def _ctx_info(self, ctx, message: str):
         """Send info to MCP client context if available."""
@@ -196,45 +215,45 @@ class OdooResourceHandler:
                     logger.warning(f"Access denied for {model}.read: {e}")
                     raise PermissionError(f"Access denied: {e}", context=context) from e
 
-                # Ensure we're connected
-                if not self.connection.is_authenticated:
-                    raise ValidationError("Not authenticated with Odoo", context=context)
+                # Access connection property (validates authentication)
+                connection = self.connection
 
-            # Search for the record to check if it exists
-            record_ids = self.connection.search(model, [("id", "=", record_id_int)])
+                # Search for the record to check if it exists
+                record_ids = connection.search(model, [("id", "=", record_id_int)])
 
-            if not record_ids:
-                raise NotFoundError(
-                    f"Record not found: {model} with ID {record_id} does not exist", context=context
-                )
+                if not record_ids:
+                    raise NotFoundError(
+                        f"Record not found: {model} with ID {record_id} does not exist",
+                        context=context,
+                    )
 
-            # Read the record with smart field selection to avoid serialization issues
-            # Get field metadata to determine which fields to fetch
-            try:
-                fields_info = self.connection.fields_get(model)
-                # Filter out fields that might cause serialization issues
-                safe_fields = []
-                for field_name, field_info in fields_info.items():
-                    field_type = field_info.get("type", "")
-                    # Skip fields that commonly cause XML-RPC serialization issues
-                    # Expanded list to include html fields which often contain Markup objects
-                    problematic_types = ["binary", "serialized", "html"]
-                    if (
-                        field_type not in problematic_types
-                        and not field_name.startswith("__")
-                        and not field_name.startswith("_")
-                    ):  # Also skip private fields
-                        safe_fields.append(field_name)
+                # Read the record with smart field selection to avoid serialization issues
+                # Get field metadata to determine which fields to fetch
+                try:
+                    fields_info = connection.fields_get(model)
+                    # Filter out fields that might cause serialization issues
+                    safe_fields = []
+                    for field_name, field_info in fields_info.items():
+                        field_type = field_info.get("type", "")
+                        # Skip fields that commonly cause XML-RPC serialization issues
+                        # Expanded list to include html fields which often contain Markup objects
+                        problematic_types = ["binary", "serialized", "html"]
+                        if (
+                            field_type not in problematic_types
+                            and not field_name.startswith("__")
+                            and not field_name.startswith("_")
+                        ):  # Also skip private fields
+                            safe_fields.append(field_name)
 
-                if safe_fields:
-                    records = self.connection.read(model, record_ids, safe_fields)
-                else:
-                    # Fallback to all fields if we can't determine safe fields
-                    records = self.connection.read(model, record_ids)
-            except Exception as e:
-                logger.debug(f"Could not get field metadata, reading all fields: {e}")
-                # If we can't get field info, try to read all fields
-                records = self.connection.read(model, record_ids)
+                    if safe_fields:
+                        records = connection.read(model, record_ids, safe_fields)
+                    else:
+                        # Fallback to all fields if we can't determine safe fields
+                        records = connection.read(model, record_ids)
+                except Exception as e:
+                    logger.debug(f"Could not get field metadata, reading all fields: {e}")
+                    # If we can't get field info, try to read all fields
+                    records = connection.read(model, record_ids)
 
             if not records:
                 raise NotFoundError(f"Record not found: {model} with ID {record_id} does not exist")
@@ -293,9 +312,8 @@ class OdooResourceHandler:
                 logger.warning(f"Access denied for {model}.read: {e}")
                 raise PermissionError(f"Access denied: {e}") from e
 
-            # Ensure we're connected
-            if not self.connection.is_authenticated:
-                raise ValidationError("Not authenticated with Odoo")
+            # Access connection property (validates authentication)
+            connection = self.connection
 
             # Parse parameters
             parsed_domain = self._parse_domain(domain)
@@ -305,21 +323,21 @@ class OdooResourceHandler:
             order_value = self._parse_order(order)
 
             # Get total count for pagination
-            total_count = self.connection.search_count(model, parsed_domain)
+            total_count = connection.search_count(model, parsed_domain)
 
             # Perform search
-            record_ids = self.connection.search(
+            record_ids = connection.search(
                 model, parsed_domain, limit=limit_value, offset=offset_value, order=order_value
             )
 
             # Read records if any found
             records = []
             if record_ids:
-                records = self.connection.read(model, record_ids, fields_list)
+                records = connection.read(model, record_ids, fields_list)
 
             # Get field metadata for formatting
             try:
-                fields_metadata = self.connection.fields_get(model)
+                fields_metadata = connection.fields_get(model)
             except Exception as e:
                 logger.debug(f"Could not retrieve field metadata: {e}")
                 fields_metadata = None
@@ -533,9 +551,8 @@ class OdooResourceHandler:
                 logger.warning(f"Access denied for {model}.read: {e}")
                 raise PermissionError(f"Access denied: {e}") from e
 
-            # Ensure we're connected
-            if not self.connection.is_authenticated:
-                raise ValidationError("Not authenticated with Odoo")
+            # Access connection property (validates authentication)
+            connection = self.connection
 
             # Parse IDs
             id_list = self._parse_ids(ids)
@@ -545,7 +562,7 @@ class OdooResourceHandler:
             # Read records in batch with smart field selection to avoid serialization issues
             # Get field metadata to determine which fields to fetch
             try:
-                fields_info = self.connection.fields_get(model)
+                fields_info = connection.fields_get(model)
                 # Filter out fields that might cause serialization issues
                 safe_fields = []
                 for field_name, field_info in fields_info.items():
@@ -561,18 +578,18 @@ class OdooResourceHandler:
                         safe_fields.append(field_name)
 
                 if safe_fields:
-                    records = self.connection.read(model, id_list, safe_fields)
+                    records = connection.read(model, id_list, safe_fields)
                 else:
                     # Fallback to all fields if we can't determine safe fields
-                    records = self.connection.read(model, id_list)
+                    records = connection.read(model, id_list)
             except Exception as e:
                 logger.debug(f"Could not get field metadata, reading all fields: {e}")
                 # If we can't get field info, try to read all fields
-                records = self.connection.read(model, id_list)
+                records = connection.read(model, id_list)
 
             # Get field metadata for formatting
             try:
-                fields_metadata = self.connection.fields_get(model)
+                fields_metadata = connection.fields_get(model)
             except Exception as e:
                 logger.debug(f"Could not retrieve field metadata: {e}")
                 fields_metadata = None
@@ -619,15 +636,14 @@ class OdooResourceHandler:
                 logger.warning(f"Access denied for {model}.read: {e}")
                 raise PermissionError(f"Access denied: {e}") from e
 
-            # Ensure we're connected
-            if not self.connection.is_authenticated:
-                raise ValidationError("Not authenticated with Odoo")
+            # Access connection property (validates authentication)
+            connection = self.connection
 
             # Parse domain
             parsed_domain = self._parse_domain(domain)
 
             # Get count
-            count = self.connection.search_count(model, parsed_domain)
+            count = connection.search_count(model, parsed_domain)
 
             # Format result
             formatted_result = self._format_count_result(model, count, parsed_domain)
@@ -668,12 +684,11 @@ class OdooResourceHandler:
                 logger.warning(f"Access denied for {model}.read: {e}")
                 raise PermissionError(f"Access denied: {e}") from e
 
-            # Ensure we're connected
-            if not self.connection.is_authenticated:
-                raise ValidationError("Not authenticated with Odoo")
+            # Access connection property (validates authentication)
+            connection = self.connection
 
             # Get field definitions
-            fields = self.connection.fields_get(model)
+            fields = connection.fields_get(model)
 
             # Format result
             formatted_result = self._format_fields_result(model, fields)
@@ -873,7 +888,7 @@ class OdooResourceHandler:
 
 def register_resources(
     app: FastMCP,
-    connection: OdooConnection,
+    server: "OdooMCPServer",
     access_controller: AccessController,
     config: OdooConfig,
 ) -> OdooResourceHandler:
@@ -881,13 +896,13 @@ def register_resources(
 
     Args:
         app: FastMCP application instance
-        connection: Odoo connection instance
+        server: OdooMCPServer instance (for dynamic connection access)
         access_controller: Access control instance
         config: Odoo configuration instance
 
     Returns:
         The resource handler instance
     """
-    handler = OdooResourceHandler(app, connection, access_controller, config)
+    handler = OdooResourceHandler(app, server, access_controller, config)
     logger.info("Registered Odoo MCP resources")
     return handler

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -7,7 +7,7 @@ and functionality through the Model Context Protocol.
 import contextlib
 from typing import Any, Dict, Optional
 
-from mcp.server import FastMCP, TransportSecuritySettings
+from mcp.server import FastMCP
 
 from .access_control import AccessController
 from .config import OdooConfig, get_config
@@ -61,24 +61,6 @@ class OdooMCPServer:
         self._tools_registered = False
         self._resources_registered = False
 
-        # Configure transport security for DNS rebinding protection
-        transport_security = None
-        if self.config.allowed_hosts:
-            # Build allowed_hosts with wildcard ports
-            allowed_hosts = [
-                f"{h}:*" if ":" not in h else h for h in self.config.allowed_hosts
-            ]
-            # Build allowed_origins from hosts
-            allowed_origins = []
-            for h in self.config.allowed_hosts:
-                base = h.split(":")[0] if ":" in h else h
-                allowed_origins.extend([f"http://{base}:*", f"https://{base}:*"])
-
-            transport_security = TransportSecuritySettings(
-                enable_dns_rebinding_protection=True,
-                allowed_hosts=allowed_hosts,
-                allowed_origins=allowed_origins,
-            )
         # Create FastMCP instance with server metadata
         self.app = FastMCP(
             name="odoo-mcp-server",
@@ -210,9 +192,7 @@ class OdooMCPServer:
             return
         if self.connection and self.access_controller:
             # Pass server reference so handlers can access connection dynamically
-            self.tool_handler = register_tools(
-                self.app, self, self.access_controller, self.config
-            )
+            self.tool_handler = register_tools(self.app, self, self.access_controller, self.config)
             self._tools_registered = True
             logger.info("Registered MCP tools")
 

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -7,7 +7,7 @@ and functionality through the Model Context Protocol.
 import contextlib
 from typing import Any, Dict, Optional
 
-from mcp.server import FastMCP
+from mcp.server import FastMCP, TransportSecuritySettings
 
 from .access_control import AccessController
 from .config import OdooConfig, get_config
@@ -57,6 +57,28 @@ class OdooMCPServer:
         self.resource_handler = None
         self.tool_handler = None
 
+        # Registration flags to prevent multiple registrations (idempotency)
+        self._tools_registered = False
+        self._resources_registered = False
+
+        # Configure transport security for DNS rebinding protection
+        transport_security = None
+        if self.config.allowed_hosts:
+            # Build allowed_hosts with wildcard ports
+            allowed_hosts = [
+                f"{h}:*" if ":" not in h else h for h in self.config.allowed_hosts
+            ]
+            # Build allowed_origins from hosts
+            allowed_origins = []
+            for h in self.config.allowed_hosts:
+                base = h.split(":")[0] if ":" in h else h
+                allowed_origins.extend([f"http://{base}:*", f"https://{base}:*"])
+
+            transport_security = TransportSecuritySettings(
+                enable_dns_rebinding_protection=True,
+                allowed_hosts=allowed_hosts,
+                allowed_origins=allowed_origins,
+            )
         # Create FastMCP instance with server metadata
         self.app = FastMCP(
             name="odoo-mcp-server",
@@ -140,7 +162,13 @@ class OdooMCPServer:
                 error_handler.handle_error(e, context=context)
 
     def _cleanup_connection(self):
-        """Clean up Odoo connection."""
+        """Clean up Odoo connection.
+
+        Note: We preserve tool_handler and resource_handler references because
+        they are still registered with FastMCP and will access the connection
+        dynamically via the server reference. Only the connection itself is
+        cleared and will be re-established on lifespan re-entry.
+        """
         if self.connection:
             try:
                 logger.info("Closing Odoo connection...")
@@ -148,26 +176,44 @@ class OdooMCPServer:
             except Exception as e:
                 logger.error(f"Error closing connection: {e}")
             finally:
-                # Always clear connection reference
+                # Clear connection reference - will be re-established on re-entry
                 self.connection = None
                 self.access_controller = None
-                self.resource_handler = None
-                self.tool_handler = None
+                # Note: Don't clear tool_handler/resource_handler - they're still
+                # registered with FastMCP and access connection via server reference
 
     def _register_resources(self):
-        """Register resource handlers after connection is established."""
+        """Register resource handlers after connection is established.
+
+        This method is idempotent - it will only register resources once.
+        On subsequent calls (e.g., lifespan re-entry), it skips registration.
+        """
+        if self._resources_registered:
+            logger.debug("Resources already registered, skipping")
+            return
         if self.connection and self.access_controller:
+            # Pass server reference so handlers can access connection dynamically
             self.resource_handler = register_resources(
-                self.app, self.connection, self.access_controller, self.config
+                self.app, self, self.access_controller, self.config
             )
+            self._resources_registered = True
             logger.info("Registered MCP resources")
 
     def _register_tools(self):
-        """Register tool handlers after connection is established."""
+        """Register tool handlers after connection is established.
+
+        This method is idempotent - it will only register tools once.
+        On subsequent calls (e.g., lifespan re-entry), it skips registration.
+        """
+        if self._tools_registered:
+            logger.debug("Tools already registered, skipping")
+            return
         if self.connection and self.access_controller:
+            # Pass server reference so handlers can access connection dynamically
             self.tool_handler = register_tools(
-                self.app, self.connection, self.access_controller, self.config
+                self.app, self, self.access_controller, self.config
             )
+            self._tools_registered = True
             logger.info("Registered MCP tools")
 
     async def run_stdio(self):

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -7,7 +7,7 @@ actions like creating, updating, or deleting records.
 
 import json
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
@@ -32,6 +32,9 @@ from .schemas import (
     UpdateResult,
 )
 
+if TYPE_CHECKING:
+    from .server import OdooMCPServer
+
 logger = get_logger(__name__)
 
 
@@ -41,7 +44,7 @@ class OdooToolHandler:
     def __init__(
         self,
         app: FastMCP,
-        connection: OdooConnection,
+        server: "OdooMCPServer",
         access_controller: AccessController,
         config: OdooConfig,
     ):
@@ -49,17 +52,33 @@ class OdooToolHandler:
 
         Args:
             app: FastMCP application instance
-            connection: Odoo connection instance
+            server: OdooMCPServer instance (for dynamic connection access)
             access_controller: Access control instance
             config: Odoo configuration instance
         """
         self.app = app
-        self.connection = connection
+        self._server = server  # Store server reference for dynamic connection access
         self.access_controller = access_controller
         self.config = config
 
         # Register tools
         self._register_tools()
+
+    @property
+    def connection(self) -> OdooConnection:
+        """Get the current connection from the server.
+
+        This property provides dynamic access to the connection,
+        ensuring we always use the current connection even after
+        lifespan re-entry in HTTP transport.
+
+        Raises:
+            ValidationError: If not authenticated with Odoo
+        """
+        conn = self._server.connection
+        if not conn or not conn.is_authenticated:
+            raise ValidationError("Not authenticated with Odoo")
+        return conn
 
     def _format_datetime(self, value: str) -> str:
         """Format datetime values to ISO 8601 with timezone."""
@@ -84,8 +103,16 @@ class OdooToolHandler:
 
         return value
 
-    def _process_record_dates(self, record: Dict[str, Any], model: str) -> Dict[str, Any]:
-        """Process datetime fields in a record to ensure proper formatting."""
+    def _process_record_dates(
+        self, record: Dict[str, Any], model: str, connection: Optional[OdooConnection] = None
+    ) -> Dict[str, Any]:
+        """Process datetime fields in a record to ensure proper formatting.
+
+        Args:
+            record: The record data to process
+            model: The Odoo model name
+            connection: Optional connection to use (if not provided, uses self.connection)
+        """
         # Common datetime field names in Odoo
         known_datetime_fields = {
             "create_date",
@@ -107,7 +134,8 @@ class OdooToolHandler:
         # First try to get field metadata
         fields_info = None
         try:
-            fields_info = self.connection.fields_get(model)
+            conn = connection if connection is not None else self.connection
+            fields_info = conn.fields_get(model)
         except Exception:
             # Field metadata unavailable, will use fallback detection
             pass
@@ -260,18 +288,22 @@ class OdooToolHandler:
 
         return max(score, 0)
 
-    def _get_smart_default_fields(self, model: str) -> Optional[List[str]]:
+    def _get_smart_default_fields(
+        self, model: str, connection: Optional[OdooConnection] = None
+    ) -> Optional[List[str]]:
         """Get smart default fields for a model using field importance scoring.
 
         Args:
             model: The Odoo model name
+            connection: Optional connection to use (if not provided, uses self.connection)
 
         Returns:
             List of field names to include by default, or None if unable to determine
         """
         try:
             # Get all field definitions
-            fields_info = self.connection.fields_get(model)
+            conn = connection if connection is not None else self.connection
+            fields_info = conn.fields_get(model)
 
             # Score all fields by importance
             field_scores = []
@@ -574,9 +606,8 @@ class OdooToolHandler:
                 self.access_controller.validate_model_access(model, "read")
                 await self._ctx_info(ctx, f"Searching {model}...")
 
-                # Ensure we're connected
-                if not self.connection.is_authenticated:
-                    raise ValidationError("Not authenticated with Odoo")
+                # Access connection property (validates authentication)
+                connection = self.connection
 
                 # Handle domain parameter - can be string or list
                 parsed_domain = []
@@ -648,11 +679,11 @@ class OdooToolHandler:
                     limit = self.config.default_limit
 
                 # Get total count
-                total_count = self.connection.search_count(model, parsed_domain)
+                total_count = connection.search_count(model, parsed_domain)
                 await self._ctx_progress(ctx, 1, 3, f"Found {total_count} records")
 
                 # Search for records
-                record_ids = self.connection.search(
+                record_ids = connection.search(
                     model, parsed_domain, limit=limit, offset=offset, order=order
                 )
 
@@ -660,7 +691,7 @@ class OdooToolHandler:
                 fields_to_fetch = parsed_fields
                 if parsed_fields is None:
                     # Use smart field selection to avoid serialization issues
-                    fields_to_fetch = self._get_smart_default_fields(model)
+                    fields_to_fetch = self._get_smart_default_fields(model, connection)
                     await self._ctx_info(ctx, f"Using smart field defaults for {model}")
                     logger.debug(
                         f"Using smart defaults for {model} search: {len(fields_to_fetch) if fields_to_fetch else 'all'} fields"
@@ -677,9 +708,9 @@ class OdooToolHandler:
                 # Read records
                 records = []
                 if record_ids:
-                    records = self.connection.read(model, record_ids, fields_to_fetch)
+                    records = connection.read(model, record_ids, fields_to_fetch)
                     # Process datetime fields in each record
-                    records = [self._process_record_dates(record, model) for record in records]
+                    records = [self._process_record_dates(record, model, connection) for record in records]
                 await self._ctx_progress(ctx, 3, 3, f"Returning {len(records)} records")
 
                 return {
@@ -713,9 +744,8 @@ class OdooToolHandler:
                 self.access_controller.validate_model_access(model, "read")
                 await self._ctx_info(ctx, f"Getting {model}/{record_id}...")
 
-                # Ensure we're connected
-                if not self.connection.is_authenticated:
-                    raise ValidationError("Not authenticated with Odoo")
+                # Access connection property (validates authentication)
+                connection = self.connection
 
                 # Determine which fields to fetch
                 fields_to_fetch = fields
@@ -725,7 +755,7 @@ class OdooToolHandler:
 
                 if fields is None:
                     # Use smart field selection
-                    fields_to_fetch = self._get_smart_default_fields(model)
+                    fields_to_fetch = self._get_smart_default_fields(model, connection)
                     use_smart_defaults = True
                     field_selection_method = "smart_defaults"
                     logger.debug(
@@ -741,19 +771,19 @@ class OdooToolHandler:
                     logger.debug(f"Fetching specific fields for {model}: {fields}")
 
                 # Read the record
-                records = self.connection.read(model, [record_id], fields_to_fetch)
+                records = connection.read(model, [record_id], fields_to_fetch)
 
                 if not records:
                     raise ValidationError(f"Record not found: {model} with ID {record_id}")
 
                 # Process datetime fields in the record
-                record = self._process_record_dates(records[0], model)
+                record = self._process_record_dates(records[0], model, connection)
 
                 # Build metadata when using smart defaults
                 metadata = None
                 if use_smart_defaults:
                     try:
-                        all_fields_info = self.connection.fields_get(model)
+                        all_fields_info = connection.fields_get(model)
                         total_fields = len(all_fields_info)
                     except Exception:
                         pass
@@ -1001,16 +1031,15 @@ class OdooToolHandler:
                 self.access_controller.validate_model_access(model, "create")
                 await self._ctx_info(ctx, f"Creating record in {model}...")
 
-                # Ensure we're connected
-                if not self.connection.is_authenticated:
-                    raise ValidationError("Not authenticated with Odoo")
+                # Access connection property (validates authentication)
+                connection = self.connection
 
                 # Validate required fields
                 if not values:
                     raise ValidationError("No values provided for record creation")
 
                 # Create the record
-                record_id = self.connection.create(model, values)
+                record_id = connection.create(model, values)
 
                 # Return only essential fields to minimize context usage
                 # Users can use get_record if they need more fields
@@ -1018,16 +1047,16 @@ class OdooToolHandler:
                 essential_fields = ["id", "display_name"]
 
                 # Read only the essential fields
-                records = self.connection.read(model, [record_id], essential_fields)
+                records = connection.read(model, [record_id], essential_fields)
                 if not records:
                     raise ValidationError(
                         f"Failed to read created record: {model} with ID {record_id}"
                     )
 
                 # Process dates in the minimal record
-                record = self._process_record_dates(records[0], model)
+                record = self._process_record_dates(records[0], model, connection)
 
-                record_url = self.connection.build_record_url(model, record_id)
+                record_url = connection.build_record_url(model, record_id)
 
                 return {
                     "success": True,
@@ -1061,21 +1090,20 @@ class OdooToolHandler:
                 self.access_controller.validate_model_access(model, "write")
                 await self._ctx_info(ctx, f"Updating {model}/{record_id}...")
 
-                # Ensure we're connected
-                if not self.connection.is_authenticated:
-                    raise ValidationError("Not authenticated with Odoo")
+                # Access connection property (validates authentication)
+                connection = self.connection
 
                 # Validate input
                 if not values:
                     raise ValidationError("No values provided for record update")
 
                 # Check if record exists (only fetch ID to verify existence)
-                existing = self.connection.read(model, [record_id], ["id"])
+                existing = connection.read(model, [record_id], ["id"])
                 if not existing:
                     raise NotFoundError(f"Record not found: {model} with ID {record_id}")
 
                 # Update the record
-                success = self.connection.write(model, [record_id], values)
+                success = connection.write(model, [record_id], values)
 
                 # Return only essential fields to minimize context usage
                 # Users can use get_record if they need more fields
@@ -1083,16 +1111,16 @@ class OdooToolHandler:
                 essential_fields = ["id", "display_name"]
 
                 # Read only the essential fields
-                records = self.connection.read(model, [record_id], essential_fields)
+                records = connection.read(model, [record_id], essential_fields)
                 if not records:
                     raise ValidationError(
                         f"Failed to read updated record: {model} with ID {record_id}"
                     )
 
                 # Process dates in the minimal record
-                record = self._process_record_dates(records[0], model)
+                record = self._process_record_dates(records[0], model, connection)
 
-                record_url = self.connection.build_record_url(model, record_id)
+                record_url = connection.build_record_url(model, record_id)
 
                 return {
                     "success": success,
@@ -1127,12 +1155,11 @@ class OdooToolHandler:
                 self.access_controller.validate_model_access(model, "unlink")
                 await self._ctx_info(ctx, f"Deleting {model}/{record_id}...")
 
-                # Ensure we're connected
-                if not self.connection.is_authenticated:
-                    raise ValidationError("Not authenticated with Odoo")
+                # Access connection property (validates authentication)
+                connection = self.connection
 
                 # Check if record exists and get display info
-                existing = self.connection.read(model, [record_id], ["id", "display_name"])
+                existing = connection.read(model, [record_id], ["id", "display_name"])
                 if not existing:
                     raise NotFoundError(f"Record not found: {model} with ID {record_id}")
 
@@ -1140,7 +1167,7 @@ class OdooToolHandler:
                 record_name = existing[0].get("display_name", f"ID {record_id}")
 
                 # Delete the record
-                success = self.connection.unlink(model, [record_id])
+                success = connection.unlink(model, [record_id])
 
                 return {
                     "success": success,
@@ -1165,7 +1192,7 @@ class OdooToolHandler:
 
 def register_tools(
     app: FastMCP,
-    connection: OdooConnection,
+    server: "OdooMCPServer",
     access_controller: AccessController,
     config: OdooConfig,
 ) -> OdooToolHandler:
@@ -1173,13 +1200,13 @@ def register_tools(
 
     Args:
         app: FastMCP application instance
-        connection: Odoo connection instance
+        server: OdooMCPServer instance (for dynamic connection access)
         access_controller: Access control instance
         config: Odoo configuration instance
 
     Returns:
         The tool handler instance
     """
-    handler = OdooToolHandler(app, connection, access_controller, config)
+    handler = OdooToolHandler(app, server, access_controller, config)
     logger.info("Registered Odoo MCP tools")
     return handler

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -710,7 +710,9 @@ class OdooToolHandler:
                 if record_ids:
                     records = connection.read(model, record_ids, fields_to_fetch)
                     # Process datetime fields in each record
-                    records = [self._process_record_dates(record, model, connection) for record in records]
+                    records = [
+                        self._process_record_dates(record, model, connection) for record in records
+                    ]
                 await self._ctx_progress(ctx, 3, 3, f"Returning {len(records)} records")
 
                 return {

--- a/tests/test_advanced_resources.py
+++ b/tests/test_advanced_resources.py
@@ -57,6 +57,14 @@ def mock_connection():
 
 
 @pytest.fixture
+def mock_server(mock_connection):
+    """Create a mock server with a connection attribute."""
+    server = Mock()
+    server.connection = mock_connection
+    return server
+
+
+@pytest.fixture
 def mock_access_controller():
     """Create a mock access controller."""
     controller = Mock(spec=AccessController)
@@ -84,9 +92,9 @@ def mock_app():
 
 
 @pytest.fixture
-def resource_handler(mock_app, mock_connection, mock_access_controller, mock_config):
+def resource_handler(mock_app, mock_server, mock_access_controller, mock_config):
     """Create a resource handler instance."""
-    return OdooResourceHandler(mock_app, mock_connection, mock_access_controller, mock_config)
+    return OdooResourceHandler(mock_app, mock_server, mock_access_controller, mock_config)
 
 
 class TestBrowseResource:
@@ -531,7 +539,12 @@ class TestAdvancedResourceIntegration:
         app.resource.side_effect = resource_decorator
 
         access_controller = AccessController(real_config)
-        handler = OdooResourceHandler(app, real_connection, access_controller, real_config)
+
+        # Create a mock server wrapper for the real connection
+        mock_server = Mock()
+        mock_server.connection = real_connection
+
+        handler = OdooResourceHandler(app, mock_server, access_controller, real_config)
 
         # Authenticate
         real_connection.connect()
@@ -571,7 +584,12 @@ class TestAdvancedResourceIntegration:
         app.resource.side_effect = resource_decorator
 
         access_controller = AccessController(real_config)
-        handler = OdooResourceHandler(app, real_connection, access_controller, real_config)
+
+        # Create a mock server wrapper for the real connection
+        mock_server = Mock()
+        mock_server.connection = real_connection
+
+        handler = OdooResourceHandler(app, mock_server, access_controller, real_config)
 
         # Authenticate
         real_connection.connect()
@@ -608,7 +626,12 @@ class TestAdvancedResourceIntegration:
         app.resource.side_effect = resource_decorator
 
         access_controller = AccessController(real_config)
-        handler = OdooResourceHandler(app, real_connection, access_controller, real_config)
+
+        # Create a mock server wrapper for the real connection
+        mock_server = Mock()
+        mock_server.connection = real_connection
+
+        handler = OdooResourceHandler(app, mock_server, access_controller, real_config)
 
         # Authenticate
         real_connection.connect()

--- a/tests/test_basic_resources.py
+++ b/tests/test_basic_resources.py
@@ -66,6 +66,14 @@ def mock_connection():
 
 
 @pytest.fixture
+def mock_server(mock_connection):
+    """Create a mock server with connection attribute."""
+    server = Mock()
+    server.connection = mock_connection
+    return server
+
+
+@pytest.fixture
 def mock_access_controller():
     """Create mock AccessController."""
     controller = Mock(spec=AccessController)
@@ -84,22 +92,22 @@ def mock_app():
 
 
 @pytest.fixture
-def resource_handler(mock_app, mock_connection, mock_access_controller, mock_config):
+def resource_handler(mock_app, mock_server, mock_access_controller, mock_config):
     """Create OdooResourceHandler instance."""
-    return OdooResourceHandler(mock_app, mock_connection, mock_access_controller, mock_config)
+    return OdooResourceHandler(mock_app, mock_server, mock_access_controller, mock_config)
 
 
 class TestOdooResourceHandler:
     """Test OdooResourceHandler functionality."""
 
-    def test_init(self, mock_app, mock_connection, mock_access_controller, mock_config):
+    def test_init(self, mock_app, mock_server, mock_access_controller, mock_config):
         """Test handler initialization."""
         handler = OdooResourceHandler(
-            mock_app, mock_connection, mock_access_controller, mock_config
+            mock_app, mock_server, mock_access_controller, mock_config
         )
 
         assert handler.app == mock_app
-        assert handler.connection == mock_connection
+        assert handler._server == mock_server
         assert handler.access_controller == mock_access_controller
         assert handler.config == mock_config
 
@@ -296,14 +304,14 @@ class TestRegisterResources:
     """Test register_resources function."""
 
     def test_register_resources(
-        self, mock_app, mock_connection, mock_access_controller, mock_config
+        self, mock_app, mock_server, mock_access_controller, mock_config
     ):
         """Test resource registration."""
-        handler = register_resources(mock_app, mock_connection, mock_access_controller, mock_config)
+        handler = register_resources(mock_app, mock_server, mock_access_controller, mock_config)
 
         assert isinstance(handler, OdooResourceHandler)
         assert handler.app == mock_app
-        assert handler.connection == mock_connection
+        assert handler._server == mock_server
         assert handler.access_controller == mock_access_controller
         assert handler.config == mock_config
 

--- a/tests/test_basic_resources.py
+++ b/tests/test_basic_resources.py
@@ -114,6 +114,44 @@ class TestOdooResourceHandler:
         # Check that resources were registered
         assert mock_app.resource.call_count >= 1
 
+    def test_connection_property_returns_connection(
+        self, resource_handler, mock_connection
+    ):
+        """Test connection property returns connection when authenticated."""
+        conn = resource_handler.connection
+        assert conn is mock_connection
+
+    def test_connection_property_raises_when_none(
+        self, mock_app, mock_access_controller, mock_config
+    ):
+        """Test connection property raises ValidationError when connection is None."""
+        mock_server = Mock()
+        mock_server.connection = None
+
+        handler = OdooResourceHandler(
+            mock_app, mock_server, mock_access_controller, mock_config
+        )
+
+        with pytest.raises(ValidationError, match="Not authenticated with Odoo"):
+            _ = handler.connection
+
+    def test_connection_property_raises_when_not_authenticated(
+        self, mock_app, mock_access_controller, mock_config
+    ):
+        """Test connection property raises ValidationError when not authenticated."""
+        mock_connection = Mock(spec=OdooConnection)
+        mock_connection.is_authenticated = False
+
+        mock_server = Mock()
+        mock_server.connection = mock_connection
+
+        handler = OdooResourceHandler(
+            mock_app, mock_server, mock_access_controller, mock_config
+        )
+
+        with pytest.raises(ValidationError, match="Not authenticated with Odoo"):
+            _ = handler.connection
+
     @pytest.mark.asyncio
     async def test_handle_record_retrieval_success(
         self, resource_handler, mock_connection, mock_access_controller

--- a/tests/test_basic_resources.py
+++ b/tests/test_basic_resources.py
@@ -102,9 +102,7 @@ class TestOdooResourceHandler:
 
     def test_init(self, mock_app, mock_server, mock_access_controller, mock_config):
         """Test handler initialization."""
-        handler = OdooResourceHandler(
-            mock_app, mock_server, mock_access_controller, mock_config
-        )
+        handler = OdooResourceHandler(mock_app, mock_server, mock_access_controller, mock_config)
 
         assert handler.app == mock_app
         assert handler._server == mock_server
@@ -114,9 +112,7 @@ class TestOdooResourceHandler:
         # Check that resources were registered
         assert mock_app.resource.call_count >= 1
 
-    def test_connection_property_returns_connection(
-        self, resource_handler, mock_connection
-    ):
+    def test_connection_property_returns_connection(self, resource_handler, mock_connection):
         """Test connection property returns connection when authenticated."""
         conn = resource_handler.connection
         assert conn is mock_connection
@@ -128,9 +124,7 @@ class TestOdooResourceHandler:
         mock_server = Mock()
         mock_server.connection = None
 
-        handler = OdooResourceHandler(
-            mock_app, mock_server, mock_access_controller, mock_config
-        )
+        handler = OdooResourceHandler(mock_app, mock_server, mock_access_controller, mock_config)
 
         with pytest.raises(ValidationError, match="Not authenticated with Odoo"):
             _ = handler.connection
@@ -145,9 +139,7 @@ class TestOdooResourceHandler:
         mock_server = Mock()
         mock_server.connection = mock_connection
 
-        handler = OdooResourceHandler(
-            mock_app, mock_server, mock_access_controller, mock_config
-        )
+        handler = OdooResourceHandler(mock_app, mock_server, mock_access_controller, mock_config)
 
         with pytest.raises(ValidationError, match="Not authenticated with Odoo"):
             _ = handler.connection
@@ -341,9 +333,7 @@ class TestOdooResourceHandler:
 class TestRegisterResources:
     """Test register_resources function."""
 
-    def test_register_resources(
-        self, mock_app, mock_server, mock_access_controller, mock_config
-    ):
+    def test_register_resources(self, mock_app, mock_server, mock_access_controller, mock_config):
         """Test resource registration."""
         handler = register_resources(mock_app, mock_server, mock_access_controller, mock_config)
 

--- a/tests/test_e2e_yolo.py
+++ b/tests/test_e2e_yolo.py
@@ -19,6 +19,13 @@ from mcp_server_odoo.tools import OdooToolHandler
 from .conftest import ODOO_SERVER_AVAILABLE
 
 
+def _wrap_connection_in_server(connection):
+    """Wrap an OdooConnection in a mock server object for handler compatibility."""
+    mock_server = MagicMock()
+    mock_server.connection = connection
+    return mock_server
+
+
 @pytest.mark.skipif(not ODOO_SERVER_AVAILABLE, reason="Odoo server not available")
 @pytest.mark.yolo
 class TestYoloModeE2E:
@@ -68,7 +75,9 @@ class TestYoloModeE2E:
         # Setup tool handler
         app = MagicMock()
         access_controller = AccessController(config_read_only)
-        handler = OdooToolHandler(app, connection, access_controller, config_read_only)
+        handler = OdooToolHandler(
+            app, _wrap_connection_in_server(connection), access_controller, config_read_only
+        )
 
         # 2. List models - should work and show indicator
         # YOLO mode returns raw dict, not ModelsResult
@@ -149,7 +158,9 @@ class TestYoloModeE2E:
         # Setup tool handler
         app = MagicMock()
         access_controller = AccessController(config_full_access)
-        handler = OdooToolHandler(app, connection, access_controller, config_full_access)
+        handler = OdooToolHandler(
+            app, _wrap_connection_in_server(connection), access_controller, config_full_access
+        )
 
         # 2. List models - should work and show warning
         # YOLO mode returns raw dict, not ModelsResult
@@ -240,7 +251,9 @@ class TestYoloModeE2E:
 
         app = MagicMock()
         access_controller = AccessController(config_full_access)
-        handler = OdooToolHandler(app, connection, access_controller, config_full_access)
+        handler = OdooToolHandler(
+            app, _wrap_connection_in_server(connection), access_controller, config_full_access
+        )
 
         # Test standard models
         standard_models = ["res.partner", "res.users", "res.company", "res.country"]
@@ -280,7 +293,9 @@ class TestYoloModeE2E:
 
         app = MagicMock()
         access_controller = AccessController(config_full_access)
-        handler = OdooToolHandler(app, connection, access_controller, config_full_access)
+        handler = OdooToolHandler(
+            app, _wrap_connection_in_server(connection), access_controller, config_full_access
+        )
 
         # Test invalid model name
         with pytest.raises(ValidationError) as exc_info:
@@ -338,7 +353,9 @@ class TestYoloModeE2E:
 
         app = MagicMock()
         access_controller = AccessController(config_read_only)
-        handler = OdooToolHandler(app, connection, access_controller, config_read_only)
+        handler = OdooToolHandler(
+            app, _wrap_connection_in_server(connection), access_controller, config_read_only
+        )
 
         # Check list_models indicator
         models_result = await handler._handle_list_models_tool()
@@ -355,7 +372,9 @@ class TestYoloModeE2E:
         connection.authenticate()
 
         access_controller = AccessController(config_full_access)
-        handler = OdooToolHandler(app, connection, access_controller, config_full_access)
+        handler = OdooToolHandler(
+            app, _wrap_connection_in_server(connection), access_controller, config_full_access
+        )
 
         # Check list_models indicator
         models_result = await handler._handle_list_models_tool()
@@ -381,7 +400,9 @@ class TestYoloModeE2E:
 
         app = MagicMock()
         access_controller = AccessController(config_full_access)
-        handler = OdooToolHandler(app, connection, access_controller, config_full_access)
+        handler = OdooToolHandler(
+            app, _wrap_connection_in_server(connection), access_controller, config_full_access
+        )
 
         # Measure list_models performance
         start_time = time.time()

--- a/tests/test_error_sanitization_integration.py
+++ b/tests/test_error_sanitization_integration.py
@@ -19,24 +19,36 @@ class TestErrorSanitizationIntegration:
         """Create a tool handler with mocked dependencies."""
         app = Mock()
         connection = Mock()
+        connection.is_authenticated = True
+        server = Mock()
+        server.connection = connection
         access_controller = Mock()
         config = Mock()
         config.default_limit = 10
         config.max_limit = 100
 
-        return OdooToolHandler(app, connection, access_controller, config)
+        handler = OdooToolHandler(app, server, access_controller, config)
+        # Store mock connection reference for test access
+        handler._mock_connection = connection
+        return handler
 
     @pytest.fixture
     def resource_handler(self):
         """Create a resource handler with mocked dependencies."""
         app = Mock()
         connection = Mock()
+        connection.is_authenticated = True
+        server = Mock()
+        server.connection = connection
         access_controller = Mock()
         config = Mock()
         config.default_limit = 10
         config.max_limit = 100
 
-        return OdooResourceHandler(app, connection, access_controller, config)
+        handler = OdooResourceHandler(app, server, access_controller, config)
+        # Store mock connection reference for test access
+        handler._mock_connection = connection
+        return handler
 
     @pytest.mark.asyncio
     async def test_tool_wraps_connection_error(self, tool_handler):

--- a/tests/test_integration_e2e.py
+++ b/tests/test_integration_e2e.py
@@ -57,6 +57,8 @@ def config():
 @pytest.fixture
 def connected_env(config):
     """Create a fully connected environment with real handlers."""
+    from unittest.mock import Mock
+
     conn = OdooConnection(config)
     conn.connect()
     conn.authenticate()
@@ -64,8 +66,12 @@ def connected_env(config):
     access_controller = AccessController(config)
     app = FastMCP("test-e2e")
 
-    resource_handler = OdooResourceHandler(app, conn, access_controller, config)
-    tool_handler = OdooToolHandler(app, conn, access_controller, config)
+    # Create mock server wrapper for the real connection
+    mock_server = Mock()
+    mock_server.connection = conn
+
+    resource_handler = OdooResourceHandler(app, mock_server, access_controller, config)
+    tool_handler = OdooToolHandler(app, mock_server, access_controller, config)
 
     yield {
         "config": config,

--- a/tests/test_resource_query_params.py
+++ b/tests/test_resource_query_params.py
@@ -35,6 +35,14 @@ def mock_connection():
 
 
 @pytest.fixture
+def mock_server(mock_connection):
+    """Create a mock server with connection attribute."""
+    server = Mock()
+    server.connection = mock_connection
+    return server
+
+
+@pytest.fixture
 def mock_access_controller():
     """Create a mock access controller."""
     controller = Mock(spec=AccessController)
@@ -49,9 +57,9 @@ def fastmcp_app():
 
 
 @pytest.fixture
-def resource_handler(fastmcp_app, mock_connection, mock_access_controller, mock_config):
+def resource_handler(fastmcp_app, mock_server, mock_access_controller, mock_config):
     """Create a resource handler instance with real FastMCP app."""
-    return OdooResourceHandler(fastmcp_app, mock_connection, mock_access_controller, mock_config)
+    return OdooResourceHandler(fastmcp_app, mock_server, mock_access_controller, mock_config)
 
 
 class TestResourceQueryParameterHandling:

--- a/tests/test_search_resources.py
+++ b/tests/test_search_resources.py
@@ -37,6 +37,14 @@ def mock_connection():
 
 
 @pytest.fixture
+def mock_server(mock_connection):
+    """Create a mock server with connection attribute."""
+    server = Mock()
+    server.connection = mock_connection
+    return server
+
+
+@pytest.fixture
 def mock_access_controller():
     """Create a mock access controller."""
     controller = Mock(spec=AccessController)
@@ -64,9 +72,9 @@ def mock_app():
 
 
 @pytest.fixture
-def resource_handler(mock_app, mock_connection, mock_access_controller, mock_config):
+def resource_handler(mock_app, mock_server, mock_access_controller, mock_config):
     """Create a resource handler instance."""
-    return OdooResourceHandler(mock_app, mock_connection, mock_access_controller, mock_config)
+    return OdooResourceHandler(mock_app, mock_server, mock_access_controller, mock_config)
 
 
 @pytest.fixture
@@ -390,7 +398,12 @@ class TestSearchResourceIntegration:
         app.resource.side_effect = resource_decorator
 
         access_controller = AccessController(real_config)
-        handler = OdooResourceHandler(app, real_connection, access_controller, real_config)
+
+        # Create a mock server wrapper for the real connection
+        mock_server = Mock()
+        mock_server.connection = real_connection
+
+        handler = OdooResourceHandler(app, mock_server, access_controller, real_config)
 
         # Connect and authenticate
         real_connection.connect()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -43,6 +43,13 @@ class TestOdooToolHandler:
         return connection
 
     @pytest.fixture
+    def mock_server(self, mock_connection):
+        """Create a mock server with a connection attribute."""
+        server = MagicMock()
+        server.connection = mock_connection
+        return server
+
+    @pytest.fixture
     def mock_access_controller(self):
         """Create a mock AccessController."""
         controller = MagicMock(spec=AccessController)
@@ -60,16 +67,16 @@ class TestOdooToolHandler:
         )
 
     @pytest.fixture
-    def handler(self, mock_app, mock_connection, mock_access_controller, valid_config):
+    def handler(self, mock_app, mock_server, mock_access_controller, valid_config):
         """Create an OdooToolHandler instance."""
-        return OdooToolHandler(mock_app, mock_connection, mock_access_controller, valid_config)
+        return OdooToolHandler(mock_app, mock_server, mock_access_controller, valid_config)
 
     def test_handler_initialization(
-        self, handler, mock_app, mock_connection, mock_access_controller, valid_config
+        self, handler, mock_app, mock_server, mock_access_controller, valid_config
     ):
         """Test handler is properly initialized with correct references."""
         assert handler.app is mock_app
-        assert handler.connection is mock_connection
+        assert handler._server is mock_server
         assert handler.access_controller is mock_access_controller
         assert handler.config is valid_config
 
@@ -854,6 +861,12 @@ class TestYoloListModels:
         return connection
 
     @pytest.fixture
+    def mock_server(self, mock_connection):
+        server = MagicMock()
+        server.connection = mock_connection
+        return server
+
+    @pytest.fixture
     def mock_access_controller(self):
         return MagicMock(spec=AccessController)
 
@@ -869,8 +882,8 @@ class TestYoloListModels:
         )
 
     @pytest.fixture
-    def handler(self, mock_app, mock_connection, mock_access_controller, yolo_config):
-        return OdooToolHandler(mock_app, mock_connection, mock_access_controller, yolo_config)
+    def handler(self, mock_app, mock_server, mock_access_controller, yolo_config):
+        return OdooToolHandler(mock_app, mock_server, mock_access_controller, yolo_config)
 
     @pytest.mark.asyncio
     async def test_yolo_list_models_success(self, handler, mock_connection, mock_app, yolo_config):
@@ -906,7 +919,7 @@ class TestYoloListModels:
 
     @pytest.mark.asyncio
     async def test_yolo_list_models_full_access(
-        self, mock_app, mock_connection, mock_access_controller
+        self, mock_app, mock_connection, mock_server, mock_access_controller
     ):
         """Test list_models in YOLO 'true' mode reports full access operations."""
         config = OdooConfig(
@@ -916,7 +929,7 @@ class TestYoloListModels:
             database="test_db",
             yolo_mode="true",
         )
-        OdooToolHandler(mock_app, mock_connection, mock_access_controller, config)
+        OdooToolHandler(mock_app, mock_server, mock_access_controller, config)
 
         mock_connection.search_read.return_value = [
             {"model": "res.partner", "name": "Contact"},
@@ -972,6 +985,12 @@ class TestCreateRecordTool:
         return connection
 
     @pytest.fixture
+    def mock_server(self, mock_connection):
+        server = MagicMock()
+        server.connection = mock_connection
+        return server
+
+    @pytest.fixture
     def mock_access_controller(self):
         return MagicMock(spec=AccessController)
 
@@ -984,8 +1003,8 @@ class TestCreateRecordTool:
         )
 
     @pytest.fixture
-    def handler(self, mock_app, mock_connection, mock_access_controller, valid_config):
-        return OdooToolHandler(mock_app, mock_connection, mock_access_controller, valid_config)
+    def handler(self, mock_app, mock_server, mock_access_controller, valid_config):
+        return OdooToolHandler(mock_app, mock_server, mock_access_controller, valid_config)
 
     @pytest.mark.asyncio
     async def test_create_record_success(self, handler, mock_connection, mock_app):
@@ -1070,6 +1089,12 @@ class TestUpdateRecordTool:
         return connection
 
     @pytest.fixture
+    def mock_server(self, mock_connection):
+        server = MagicMock()
+        server.connection = mock_connection
+        return server
+
+    @pytest.fixture
     def mock_access_controller(self):
         return MagicMock(spec=AccessController)
 
@@ -1082,8 +1107,8 @@ class TestUpdateRecordTool:
         )
 
     @pytest.fixture
-    def handler(self, mock_app, mock_connection, mock_access_controller, valid_config):
-        return OdooToolHandler(mock_app, mock_connection, mock_access_controller, valid_config)
+    def handler(self, mock_app, mock_server, mock_access_controller, valid_config):
+        return OdooToolHandler(mock_app, mock_server, mock_access_controller, valid_config)
 
     @pytest.mark.asyncio
     async def test_update_record_success(self, handler, mock_connection, mock_app):
@@ -1177,6 +1202,12 @@ class TestDeleteRecordTool:
         return connection
 
     @pytest.fixture
+    def mock_server(self, mock_connection):
+        server = MagicMock()
+        server.connection = mock_connection
+        return server
+
+    @pytest.fixture
     def mock_access_controller(self):
         return MagicMock(spec=AccessController)
 
@@ -1189,8 +1220,8 @@ class TestDeleteRecordTool:
         )
 
     @pytest.fixture
-    def handler(self, mock_app, mock_connection, mock_access_controller, valid_config):
-        return OdooToolHandler(mock_app, mock_connection, mock_access_controller, valid_config)
+    def handler(self, mock_app, mock_server, mock_access_controller, valid_config):
+        return OdooToolHandler(mock_app, mock_server, mock_access_controller, valid_config)
 
     @pytest.mark.asyncio
     async def test_delete_record_success(self, handler, mock_connection, mock_app):
@@ -1274,6 +1305,12 @@ class TestListModelsTool:
         return connection
 
     @pytest.fixture
+    def mock_server(self, mock_connection):
+        server = MagicMock()
+        server.connection = mock_connection
+        return server
+
+    @pytest.fixture
     def mock_access_controller(self):
         return MagicMock(spec=AccessController)
 
@@ -1298,8 +1335,8 @@ class TestListModelsTool:
         )
 
     @pytest.fixture
-    def yolo_handler(self, mock_app, mock_connection, mock_access_controller, yolo_read_config):
-        return OdooToolHandler(mock_app, mock_connection, mock_access_controller, yolo_read_config)
+    def yolo_handler(self, mock_app, mock_server, mock_access_controller, yolo_read_config):
+        return OdooToolHandler(mock_app, mock_server, mock_access_controller, yolo_read_config)
 
     @pytest.mark.asyncio
     async def test_list_models_yolo_read_mode(self, yolo_handler, mock_connection, mock_app):
@@ -1330,10 +1367,10 @@ class TestListModelsTool:
 
     @pytest.mark.asyncio
     async def test_list_models_yolo_full_mode(
-        self, mock_app, mock_connection, mock_access_controller, yolo_full_config
+        self, mock_app, mock_server, mock_connection, mock_access_controller, yolo_full_config
     ):
         """Test list_models in YOLO full mode enables write operations."""
-        OdooToolHandler(mock_app, mock_connection, mock_access_controller, yolo_full_config)
+        OdooToolHandler(mock_app, mock_server, mock_access_controller, yolo_full_config)
         mock_connection.search_read.return_value = [
             {"model": "res.partner", "name": "Contact"},
         ]
@@ -1386,6 +1423,12 @@ class TestSearchRecordReturnValue:
         return connection
 
     @pytest.fixture
+    def mock_server(self, mock_connection):
+        server = MagicMock()
+        server.connection = mock_connection
+        return server
+
+    @pytest.fixture
     def mock_access_controller(self):
         return MagicMock(spec=AccessController)
 
@@ -1398,8 +1441,8 @@ class TestSearchRecordReturnValue:
         )
 
     @pytest.fixture
-    def handler(self, mock_app, mock_connection, mock_access_controller, valid_config):
-        return OdooToolHandler(mock_app, mock_connection, mock_access_controller, valid_config)
+    def handler(self, mock_app, mock_server, mock_access_controller, valid_config):
+        return OdooToolHandler(mock_app, mock_server, mock_access_controller, valid_config)
 
     @pytest.mark.asyncio
     async def test_search_with_complex_domain_checks_result(
@@ -1459,6 +1502,12 @@ class TestToolEdgeCases:
         return connection
 
     @pytest.fixture
+    def mock_server(self, mock_connection):
+        server = MagicMock()
+        server.connection = mock_connection
+        return server
+
+    @pytest.fixture
     def mock_access_controller(self):
         return MagicMock(spec=AccessController)
 
@@ -1471,8 +1520,8 @@ class TestToolEdgeCases:
         )
 
     @pytest.fixture
-    def handler(self, mock_app, mock_connection, mock_access_controller, valid_config):
-        return OdooToolHandler(mock_app, mock_connection, mock_access_controller, valid_config)
+    def handler(self, mock_app, mock_server, mock_access_controller, valid_config):
+        return OdooToolHandler(mock_app, mock_server, mock_access_controller, valid_config)
 
     @pytest.mark.asyncio
     async def test_list_models_access_controller_failure(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -80,6 +80,38 @@ class TestOdooToolHandler:
         assert handler.access_controller is mock_access_controller
         assert handler.config is valid_config
 
+    def test_connection_property_returns_connection(self, handler, mock_connection):
+        """Test connection property returns connection when authenticated."""
+        conn = handler.connection
+        assert conn is mock_connection
+
+    def test_connection_property_raises_when_none(
+        self, mock_app, mock_access_controller, valid_config
+    ):
+        """Test connection property raises ValidationError when connection is None."""
+        mock_server = MagicMock()
+        mock_server.connection = None
+
+        handler = OdooToolHandler(mock_app, mock_server, mock_access_controller, valid_config)
+
+        with pytest.raises(ValidationError, match="Not authenticated with Odoo"):
+            _ = handler.connection
+
+    def test_connection_property_raises_when_not_authenticated(
+        self, mock_app, mock_access_controller, valid_config
+    ):
+        """Test connection property raises ValidationError when not authenticated."""
+        mock_connection = MagicMock(spec=OdooConnection)
+        mock_connection.is_authenticated = False
+
+        mock_server = MagicMock()
+        mock_server.connection = mock_connection
+
+        handler = OdooToolHandler(mock_app, mock_server, mock_access_controller, valid_config)
+
+        with pytest.raises(ValidationError, match="Not authenticated with Odoo"):
+            _ = handler.connection
+
     def test_tools_registered(self, handler, mock_app):
         """Test that all tools are registered with FastMCP."""
         expected_tools = {

--- a/tests/test_tools_yolo.py
+++ b/tests/test_tools_yolo.py
@@ -56,6 +56,13 @@ class TestYoloModeTools:
         return mock
 
     @pytest.fixture
+    def mock_server(self, mock_connection):
+        """Create mock server with connection attribute."""
+        server = MagicMock()
+        server.connection = mock_connection
+        return server
+
+    @pytest.fixture
     def mock_access_controller(self):
         """Create mock AccessController."""
         mock = MagicMock()
@@ -71,7 +78,7 @@ class TestYoloModeTools:
 
     @pytest.mark.asyncio
     async def test_list_models_yolo_read_mode(
-        self, config_yolo_read, mock_connection, mock_access_controller, mock_app
+        self, config_yolo_read, mock_connection, mock_server, mock_access_controller, mock_app
     ):
         """Test list_models in read-only YOLO mode."""
         # Setup mock data
@@ -83,7 +90,7 @@ class TestYoloModeTools:
 
         # Create handler
         handler = OdooToolHandler(
-            mock_app, mock_connection, mock_access_controller, config_yolo_read
+            mock_app, mock_server, mock_access_controller, config_yolo_read
         )
 
         # Call the method
@@ -127,7 +134,7 @@ class TestYoloModeTools:
 
     @pytest.mark.asyncio
     async def test_list_models_yolo_full_mode(
-        self, config_yolo_full, mock_connection, mock_access_controller, mock_app
+        self, config_yolo_full, mock_connection, mock_server, mock_access_controller, mock_app
     ):
         """Test list_models in full access YOLO mode."""
         # Setup mock data
@@ -138,7 +145,7 @@ class TestYoloModeTools:
 
         # Create handler
         handler = OdooToolHandler(
-            mock_app, mock_connection, mock_access_controller, config_yolo_full
+            mock_app, mock_server, mock_access_controller, config_yolo_full
         )
 
         # Call the method
@@ -176,7 +183,7 @@ class TestYoloModeTools:
 
     @pytest.mark.asyncio
     async def test_list_models_standard_mode(
-        self, config_standard, mock_connection, mock_access_controller, mock_app
+        self, config_standard, mock_connection, mock_server, mock_access_controller, mock_app
     ):
         """Test list_models in standard mode uses MCP access controller."""
         # Setup mock data
@@ -197,7 +204,7 @@ class TestYoloModeTools:
 
         # Create handler
         handler = OdooToolHandler(
-            mock_app, mock_connection, mock_access_controller, config_standard
+            mock_app, mock_server, mock_access_controller, config_standard
         )
 
         # Call the method
@@ -221,7 +228,7 @@ class TestYoloModeTools:
 
     @pytest.mark.asyncio
     async def test_list_models_yolo_error_handling(
-        self, config_yolo_read, mock_connection, mock_access_controller, mock_app
+        self, config_yolo_read, mock_connection, mock_server, mock_access_controller, mock_app
     ):
         """Test error handling in YOLO mode model listing."""
         # Setup connection to raise error
@@ -229,7 +236,7 @@ class TestYoloModeTools:
 
         # Create handler
         handler = OdooToolHandler(
-            mock_app, mock_connection, mock_access_controller, config_yolo_read
+            mock_app, mock_server, mock_access_controller, config_yolo_read
         )
 
         # Call the method
@@ -255,14 +262,14 @@ class TestYoloModeTools:
 
     @pytest.mark.asyncio
     async def test_list_models_yolo_domain_construction(
-        self, config_yolo_read, mock_connection, mock_access_controller, mock_app
+        self, config_yolo_read, mock_connection, mock_server, mock_access_controller, mock_app
     ):
         """Test that domain is properly constructed in YOLO mode."""
         mock_connection.search_read.return_value = []
 
         # Create handler
         handler = OdooToolHandler(
-            mock_app, mock_connection, mock_access_controller, config_yolo_read
+            mock_app, mock_server, mock_access_controller, config_yolo_read
         )
 
         # Call the method and verify empty result is handled
@@ -291,7 +298,7 @@ class TestYoloModeTools:
 
     @pytest.mark.asyncio
     async def test_yolo_mode_logging(
-        self, config_yolo_read, mock_connection, mock_access_controller, mock_app, caplog
+        self, config_yolo_read, mock_connection, mock_server, mock_access_controller, mock_app, caplog
     ):
         """Test that appropriate logging occurs in YOLO mode."""
         import logging
@@ -305,7 +312,7 @@ class TestYoloModeTools:
 
         # Create handler
         handler = OdooToolHandler(
-            mock_app, mock_connection, mock_access_controller, config_yolo_read
+            mock_app, mock_server, mock_access_controller, config_yolo_read
         )
 
         # Call the method and verify result

--- a/tests/test_tools_yolo.py
+++ b/tests/test_tools_yolo.py
@@ -89,9 +89,7 @@ class TestYoloModeTools:
         ]
 
         # Create handler
-        handler = OdooToolHandler(
-            mock_app, mock_server, mock_access_controller, config_yolo_read
-        )
+        handler = OdooToolHandler(mock_app, mock_server, mock_access_controller, config_yolo_read)
 
         # Call the method
         result = await handler._handle_list_models_tool()
@@ -144,9 +142,7 @@ class TestYoloModeTools:
         ]
 
         # Create handler
-        handler = OdooToolHandler(
-            mock_app, mock_server, mock_access_controller, config_yolo_full
-        )
+        handler = OdooToolHandler(mock_app, mock_server, mock_access_controller, config_yolo_full)
 
         # Call the method
         result = await handler._handle_list_models_tool()
@@ -203,9 +199,7 @@ class TestYoloModeTools:
         mock_access_controller.get_model_permissions.side_effect = mock_get_permissions
 
         # Create handler
-        handler = OdooToolHandler(
-            mock_app, mock_server, mock_access_controller, config_standard
-        )
+        handler = OdooToolHandler(mock_app, mock_server, mock_access_controller, config_standard)
 
         # Call the method
         result = await handler._handle_list_models_tool()
@@ -235,9 +229,7 @@ class TestYoloModeTools:
         mock_connection.search_read.side_effect = Exception("Database connection failed")
 
         # Create handler
-        handler = OdooToolHandler(
-            mock_app, mock_server, mock_access_controller, config_yolo_read
-        )
+        handler = OdooToolHandler(mock_app, mock_server, mock_access_controller, config_yolo_read)
 
         # Call the method
         result = await handler._handle_list_models_tool()
@@ -268,9 +260,7 @@ class TestYoloModeTools:
         mock_connection.search_read.return_value = []
 
         # Create handler
-        handler = OdooToolHandler(
-            mock_app, mock_server, mock_access_controller, config_yolo_read
-        )
+        handler = OdooToolHandler(mock_app, mock_server, mock_access_controller, config_yolo_read)
 
         # Call the method and verify empty result is handled
         result = await handler._handle_list_models_tool()
@@ -298,7 +288,13 @@ class TestYoloModeTools:
 
     @pytest.mark.asyncio
     async def test_yolo_mode_logging(
-        self, config_yolo_read, mock_connection, mock_server, mock_access_controller, mock_app, caplog
+        self,
+        config_yolo_read,
+        mock_connection,
+        mock_server,
+        mock_access_controller,
+        mock_app,
+        caplog,
     ):
         """Test that appropriate logging occurs in YOLO mode."""
         import logging
@@ -311,9 +307,7 @@ class TestYoloModeTools:
         ]
 
         # Create handler
-        handler = OdooToolHandler(
-            mock_app, mock_server, mock_access_controller, config_yolo_read
-        )
+        handler = OdooToolHandler(mock_app, mock_server, mock_access_controller, config_yolo_read)
 
         # Call the method and verify result
         result = await handler._handle_list_models_tool()

--- a/tests/test_write_tools.py
+++ b/tests/test_write_tools.py
@@ -31,6 +31,13 @@ class TestWriteTools:
         return conn
 
     @pytest.fixture
+    def mock_server(self, mock_connection):
+        """Create mock server with connection attribute."""
+        server = Mock()
+        server.connection = mock_connection
+        return server
+
+    @pytest.fixture
     def mock_access_controller(self):
         """Create mock AccessController."""
         controller = Mock()
@@ -47,9 +54,9 @@ class TestWriteTools:
         return config
 
     @pytest.fixture
-    def tool_handler(self, mock_app, mock_connection, mock_access_controller, mock_config):
+    def tool_handler(self, mock_app, mock_server, mock_access_controller, mock_config):
         """Create OdooToolHandler instance."""
-        return OdooToolHandler(mock_app, mock_connection, mock_access_controller, mock_config)
+        return OdooToolHandler(mock_app, mock_server, mock_access_controller, mock_config)
 
     @pytest.mark.asyncio
     async def test_create_record_success(self, tool_handler, mock_connection):

--- a/tests/test_write_tools.py
+++ b/tests/test_write_tools.py
@@ -1,6 +1,6 @@
 """Tests for write operation tools."""
 
-from unittest.mock import Mock, call
+from unittest.mock import MagicMock, Mock, call
 
 import pytest
 
@@ -356,7 +356,10 @@ class TestWriteToolsIntegration:
     @pytest.fixture
     def real_tool_handler(self, real_app, real_connection, real_access_controller, real_config):
         """Create real tool handler."""
-        return register_tools(real_app, real_connection, real_access_controller, real_config)
+        # Wrap connection in mock server object (register_tools expects server with .connection)
+        mock_server = MagicMock()
+        mock_server.connection = real_connection
+        return register_tools(real_app, mock_server, real_access_controller, real_config)
 
     @pytest.mark.yolo
     @pytest.mark.asyncio


### PR DESCRIPTION
Problem
-------
When using HTTP transport (`run_http`), tool calls fail with "Not authenticated with Odoo" even though authentication succeeds during server startup. Additionally, "Tool already exists" warnings appear in logs indicating the lifespan context is being re-entered.

Root Cause
----------
FastMCP's HTTP transport (Starlette-based) may re-enter the lifespan context manager multiple times during the server's lifetime. This causes three issues:

1. **Connection cleared on exit**: When the lifespan context exits, `_cleanup_connection()` sets `self.connection = None`

2. **Stale closure references**: Tool and resource handlers captured `self.connection` via closures at registration time. After cleanup, these closures reference `None` instead of a valid connection.

3. **Duplicate registration**: Re-entering lifespan re-registers tools, causing "Tool already exists" warnings

Solution
--------
Two complementary fixes:

1. **Dynamic connection access via server reference**
   - Handlers now receive the `OdooMCPServer` instance instead of the connection directly
   - A `connection` property validates authentication on each access
   - Tool methods fetch the connection at call time, not registration

   Before (buggy):
   ```python
   def __init__(self, app, connection, ...):
       self.connection = connection  # captured at registration
   ```

   After (fixed):
   ```python
   def __init__(self, app, server, ...):
       self._server = server

   @property
   def connection(self):
       conn = self._server.connection
       if not conn or not conn.is_authenticated:
           raise ValidationError("Not authenticated")
       return conn
   ```

2. **Idempotent registration**
   - Added `_tools_registered` and `_resources_registered` flags
   - Registration methods skip if already registered
   - Cleanup preserves handler references (tools remain functional)

Impact on stdio Transport
-------------------------
These changes are **safe and transparent** for stdio transport:

- In stdio mode, the lifespan context enters exactly once and never re-enters, so the original behavior is preserved
- The dynamic connection property simply returns the same connection that was previously captured directly
- Idempotent registration has no effect since registration only happens once anyway
- All existing tests pass (547 tests, 172 skipped integration tests)

The changes only affect the code path when lifespan re-entry occurs, which only happens with HTTP transport.

Files Changed
-------------
- server.py: Added registration flags, made registration idempotent, pass server reference to handlers
- tools.py: Accept server reference, add connection property with validation, use local variable after property access
- resources.py: Same pattern as tools.py
- tests/*: Updated fixtures to use mock_server wrapping mock_connection