### PR TITLE
Add safe view translation tools for multilingual content

### DIFF
--- a/mcp_server_odoo/odoo_connection.py
+++ b/mcp_server_odoo/odoo_connection.py
@@ -938,7 +938,11 @@ class OdooConnection:
         return self.execute_kw(model, "search", [domain], kwargs)
 
     def read(
-        self, model: str, ids: List[int], fields: Optional[List[str]] = None
+        self,
+        model: str,
+        ids: List[int],
+        fields: Optional[List[str]] = None,
+        context: Optional[Dict[str, Any]] = None,
     ) -> List[Dict[str, Any]]:
         """Read records by IDs.
 
@@ -946,13 +950,16 @@ class OdooConnection:
             model: The Odoo model name
             ids: List of record IDs to read
             fields: List of field names to read (None for all fields)
+            context: Optional Odoo context (e.g., {"lang": "fi_FI"})
 
         Returns:
             List of dictionaries containing record data
         """
-        kwargs = {}
+        kwargs: Dict[str, Any] = {}
         if fields:
             kwargs["fields"] = fields
+        if context:
+            kwargs["context"] = context
 
         with self._performance_manager.monitor.track_operation(f"read_{model}"):
             records = self.execute_kw(model, "read", [ids], kwargs)
@@ -1025,12 +1032,18 @@ class OdooConnection:
         """
         return self.execute_kw(model, "search_count", [domain], {})
 
-    def create(self, model: str, values: Dict[str, Any]) -> int:
+    def create(
+        self,
+        model: str,
+        values: Dict[str, Any],
+        context: Optional[Dict[str, Any]] = None,
+    ) -> int:
         """Create a new record.
 
         Args:
             model: The Odoo model name
             values: Dictionary of field values for the new record
+            context: Optional Odoo context (e.g., {"lang": "fi_FI"})
 
         Returns:
             ID of the created record
@@ -1039,8 +1052,11 @@ class OdooConnection:
             OdooConnectionError: If creation fails
         """
         try:
+            kwargs: Dict[str, Any] = {}
+            if context:
+                kwargs["context"] = context
             with self._performance_manager.monitor.track_operation(f"create_{model}"):
-                record_id = self.execute_kw(model, "create", [values], {})
+                record_id = self.execute_kw(model, "create", [values], kwargs)
                 # Invalidate cache for this model
                 self._performance_manager.invalidate_record_cache(model)
                 logger.info(f"Created {model} record with ID {record_id}")
@@ -1049,13 +1065,20 @@ class OdooConnection:
             logger.error(f"Failed to create {model} record: {e}")
             raise
 
-    def write(self, model: str, ids: List[int], values: Dict[str, Any]) -> bool:
+    def write(
+        self,
+        model: str,
+        ids: List[int],
+        values: Dict[str, Any],
+        context: Optional[Dict[str, Any]] = None,
+    ) -> bool:
         """Update existing records.
 
         Args:
             model: The Odoo model name
             ids: List of record IDs to update
             values: Dictionary of field values to update
+            context: Optional Odoo context (e.g., {"lang": "fi_FI"})
 
         Returns:
             True if update was successful
@@ -1064,8 +1087,11 @@ class OdooConnection:
             OdooConnectionError: If update fails
         """
         try:
+            kwargs: Dict[str, Any] = {}
+            if context:
+                kwargs["context"] = context
             with self._performance_manager.monitor.track_operation(f"write_{model}"):
-                result = self.execute_kw(model, "write", [ids, values], {})
+                result = self.execute_kw(model, "write", [ids, values], kwargs)
                 # Invalidate cache for updated records
                 for record_id in ids:
                     self._performance_manager.invalidate_record_cache(model, record_id)

--- a/mcp_server_odoo/schemas.py
+++ b/mcp_server_odoo/schemas.py
@@ -156,3 +156,39 @@ class DeleteResult(BaseModel):
     deleted_id: int = Field(description="ID of the deleted record")
     deleted_name: str = Field(description="Display name of the deleted record")
     message: str = Field(description="Human-readable success message")
+
+
+# --- View Translations ---
+
+
+class TranslationEntry(BaseModel):
+    """A single translation term with source and translated value."""
+
+    lang: str = Field(description="Language code (e.g., 'fi_FI')")
+    source: str = Field(description="Source term in en_US")
+    value: str = Field(description="Translated term (empty string if not yet translated)")
+
+
+class ViewTranslationsResult(BaseModel):
+    """Result of reading view translations."""
+
+    translations: List[Any] = Field(
+        description="Translation terms with source and translated values"
+    )
+    translation_type: str = Field(description="Type of translation field (text/char)")
+    translation_show_source: bool = Field(
+        description="Whether source terms are available"
+    )
+    view_info: Dict[str, Any] = Field(
+        description="View metadata (name, key, write_date)"
+    )
+
+
+class UpdateViewTranslationResult(BaseModel):
+    """Result of updating view translations."""
+
+    success: bool = Field(description="Whether the translation update succeeded")
+    updated_langs: List[str] = Field(
+        description="Language codes that were updated"
+    )
+    message: str = Field(description="Human-readable success message")

--- a/mcp_server_odoo/schemas.py
+++ b/mcp_server_odoo/schemas.py
@@ -176,19 +176,13 @@ class ViewTranslationsResult(BaseModel):
         description="Translation terms with source and translated values"
     )
     translation_type: str = Field(description="Type of translation field (text/char)")
-    translation_show_source: bool = Field(
-        description="Whether source terms are available"
-    )
-    view_info: Dict[str, Any] = Field(
-        description="View metadata (name, key, write_date)"
-    )
+    translation_show_source: bool = Field(description="Whether source terms are available")
+    view_info: Dict[str, Any] = Field(description="View metadata (name, key, write_date)")
 
 
 class UpdateViewTranslationResult(BaseModel):
     """Result of updating view translations."""
 
     success: bool = Field(description="Whether the translation update succeeded")
-    updated_langs: List[str] = Field(
-        description="Language codes that were updated"
-    )
+    updated_langs: List[str] = Field(description="Language codes that were updated")
     message: str = Field(description="Human-readable success message")

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -30,6 +30,8 @@ from .schemas import (
     ResourceTemplatesResult,
     SearchResult,
     UpdateResult,
+    UpdateViewTranslationResult,
+    ViewTranslationsResult,
 )
 
 logger = get_logger(__name__)
@@ -573,6 +575,72 @@ class OdooToolHandler:
             """
             result = await self._handle_delete_record_tool(model, record_id, ctx)
             return DeleteResult(**result)
+
+        @self.app.tool(
+            title="Read View Translations",
+            annotations=ToolAnnotations(
+                readOnlyHint=True,
+                destructiveHint=False,
+                idempotentHint=True,
+                openWorldHint=False,
+            ),
+        )
+        async def read_view_translations(
+            view_id: int,
+            langs: Optional[List[str]] = None,
+            ctx: Optional[Context] = None,
+        ) -> ViewTranslationsResult:
+            """Read per-language translations of a website view's arch content.
+
+            Returns all translatable terms with their source (en_US) text and
+            translated values for each requested language. Use this to inspect
+            current translations before updating them with update_view_translation.
+
+            Args:
+                view_id: ID of the ir.ui.view record
+                langs: Language codes to include (e.g., ['en_US', 'fi_FI']).
+                    If omitted, returns all installed languages.
+
+            Returns:
+                Translation terms with source and translated values, plus view metadata.
+            """
+            result = await self._handle_read_view_translations(view_id, langs, ctx)
+            return ViewTranslationsResult(**result)
+
+        @self.app.tool(
+            title="Update View Translation",
+            annotations=ToolAnnotations(
+                readOnlyHint=False,
+                destructiveHint=False,
+                idempotentHint=True,
+                openWorldHint=False,
+            ),
+        )
+        async def update_view_translation(
+            view_id: int,
+            translations: Dict[str, Dict[str, str]],
+            ctx: Optional[Context] = None,
+        ) -> UpdateViewTranslationResult:
+            """Safely update translations for specific terms in a view's arch content.
+
+            Updates ONLY the specified language(s) and terms without affecting
+            other languages or unspecified terms. This is the safe way to edit
+            multilingual website content -- unlike update_record which can corrupt
+            other language versions when writing to translated fields like arch.
+
+            Use read_view_translations first to see available source terms.
+
+            Args:
+                view_id: ID of the ir.ui.view record
+                translations: Per-language translation updates.
+                    Format: {lang: {source_term: new_translation}}
+                    Example: {"fi_FI": {"Contact Us": "Ota yhteytta", "Learn More": "Lue lisaa"}}
+
+            Returns:
+                Success status and list of updated languages.
+            """
+            result = await self._handle_update_view_translation(view_id, translations, ctx)
+            return UpdateViewTranslationResult(**result)
 
     async def _handle_search_tool(
         self,
@@ -1192,6 +1260,131 @@ class OdooToolHandler:
             logger.error(f"Error in delete_record tool: {e}")
             sanitized_msg = ErrorSanitizer.sanitize_message(str(e))
             raise ValidationError(f"Failed to delete record: {sanitized_msg}") from e
+
+    async def _handle_read_view_translations(
+        self,
+        view_id: int,
+        langs: Optional[List[str]],
+        ctx=None,
+    ) -> Dict[str, Any]:
+        """Handle read view translations tool request."""
+        try:
+            with perf_logger.track_operation("tool_read_view_translations", model="ir.ui.view"):
+                await self._ctx_info(ctx, f"Reading translations for view {view_id}...")
+
+                if not self.connection.is_authenticated:
+                    raise ValidationError("Not authenticated with Odoo")
+
+                # Call get_field_translations via execute_kw
+                # Method signature: get_field_translations(self, field_name, langs=None)
+                # As non-@api.model, ids go in args[0]
+                kwargs = {}
+                if langs:
+                    kwargs["langs"] = langs
+                result = self.connection.execute_kw(
+                    "ir.ui.view",
+                    "get_field_translations",
+                    [[view_id], "arch_db"],
+                    kwargs,
+                )
+
+                # result is (translations_list, context_dict)
+                translations_data = result[0] if isinstance(result, (list, tuple)) else []
+                context_data = (
+                    result[1] if isinstance(result, (list, tuple)) and len(result) > 1 else {}
+                )
+
+                # Read view metadata
+                view_records = self.connection.read(
+                    "ir.ui.view",
+                    [view_id],
+                    ["name", "key", "write_date", "write_uid"],
+                )
+                view_info = view_records[0] if view_records else {}
+
+                await self._ctx_info(ctx, f"Found {len(translations_data)} translation entries")
+
+                return {
+                    "translations": translations_data,
+                    "translation_type": context_data.get("translation_type", "text"),
+                    "translation_show_source": context_data.get(
+                        "translation_show_source", True
+                    ),
+                    "view_info": view_info,
+                }
+
+        except ValidationError:
+            raise
+        except Exception as e:
+            logger.error(f"Error in read_view_translations tool: {e}")
+            sanitized_msg = ErrorSanitizer.sanitize_message(str(e))
+            raise ValidationError(
+                f"Failed to read view translations: {sanitized_msg}"
+            ) from e
+
+    async def _handle_update_view_translation(
+        self,
+        view_id: int,
+        translations: Dict[str, Dict[str, str]],
+        ctx=None,
+    ) -> Dict[str, Any]:
+        """Handle update view translation tool request."""
+        try:
+            with perf_logger.track_operation(
+                "tool_update_view_translation", model="ir.ui.view"
+            ):
+                await self._ctx_info(ctx, f"Updating translations for view {view_id}...")
+
+                if not self.connection.is_authenticated:
+                    raise ValidationError("Not authenticated with Odoo")
+
+                if not translations:
+                    raise ValidationError("No translations provided")
+
+                # Validate translation structure
+                for lang, terms in translations.items():
+                    if not isinstance(terms, dict):
+                        raise ValidationError(
+                            f"Translations for '{lang}' must be a dict of "
+                            f"{{source_term: new_translation}}, "
+                            f"got {type(terms).__name__}"
+                        )
+
+                # Call update_field_translations via execute_kw
+                # Method signature: update_field_translations(self, field_name, translations, source_lang='')
+                result = self.connection.execute_kw(
+                    "ir.ui.view",
+                    "update_field_translations",
+                    [[view_id], "arch_db", translations],
+                    {},
+                )
+
+                updated_langs = list(translations.keys())
+                total_terms = sum(len(terms) for terms in translations.values())
+
+                await self._ctx_info(
+                    ctx,
+                    f"Updated {total_terms} terms in {len(updated_langs)} language(s): "
+                    f"{', '.join(updated_langs)}",
+                )
+
+                return {
+                    "success": bool(result),
+                    "updated_langs": updated_langs,
+                    "message": (
+                        f"Successfully updated {total_terms} translation term(s) "
+                        f"for language(s): {', '.join(updated_langs)}"
+                    ),
+                }
+
+        except ValidationError:
+            raise
+        except Exception as e:
+            logger.error(f"Error in update_view_translation tool: {e}")
+            sanitized_msg = ErrorSanitizer.sanitize_message(str(e))
+            raise ValidationError(
+                f"Failed to update view translation: {sanitized_msg}"
+            ) from e
 
 
 def register_tools(

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -359,6 +359,7 @@ class OdooToolHandler:
             limit: int = 10,
             offset: int = 0,
             order: Optional[str] = None,
+            lang: Optional[str] = None,
             ctx: Optional[Context] = None,
         ) -> SearchResult:
             """Search for records in an Odoo model.
@@ -377,12 +378,14 @@ class OdooToolHandler:
                 limit: Maximum number of records to return
                 offset: Number of records to skip
                 order: Sort order (e.g., 'name asc')
+                lang: Language code for translated fields (e.g., 'fi_FI', 'en_US').
+                    Overrides the global ODOO_LOCALE setting for this call.
 
             Returns:
                 Search results with records, total count, and pagination info
             """
             result = await self._handle_search_tool(
-                model, domain, fields, limit, offset, order, ctx
+                model, domain, fields, limit, offset, order, ctx, lang=lang
             )
             return SearchResult(**result)
 
@@ -399,6 +402,7 @@ class OdooToolHandler:
             model: str,
             record_id: int,
             fields: Optional[List[str]] = None,
+            lang: Optional[str] = None,
             ctx: Optional[Context] = None,
         ) -> RecordResult:
             """Get a specific record by ID with smart field selection.
@@ -413,6 +417,8 @@ class OdooToolHandler:
                     - None (default): Returns smart selection of common fields
                     - ["field1", "field2", ...]: Returns only specified fields
                     - ["__all__"]: Returns ALL fields (warning: can be very large)
+                lang: Language code for translated fields (e.g., 'fi_FI', 'en_US').
+                    Overrides the global ODOO_LOCALE setting for this call.
 
             Workflow for field discovery:
             1. To see all available fields for a model, use the resource:
@@ -430,11 +436,14 @@ class OdooToolHandler:
                 # Get ALL fields (use with caution)
                 get_record("res.partner", 1, fields=["__all__"])
 
+                # Get Finnish translation of fields
+                get_record("ir.ui.view", 42, fields=["arch"], lang="fi_FI")
+
             Returns:
                 Record data with requested fields. When using smart defaults,
                 includes metadata with field statistics.
             """
-            return await self._handle_get_record_tool(model, record_id, fields, ctx)
+            return await self._handle_get_record_tool(model, record_id, fields, ctx, lang=lang)
 
         @self.app.tool(
             title="List Models",
@@ -489,6 +498,7 @@ class OdooToolHandler:
         async def create_record(
             model: str,
             values: Dict[str, Any],
+            lang: Optional[str] = None,
             ctx: Optional[Context] = None,
         ) -> CreateResult:
             """Create a new record in an Odoo model.
@@ -496,11 +506,13 @@ class OdooToolHandler:
             Args:
                 model: The Odoo model name (e.g., 'res.partner')
                 values: Field values for the new record
+                lang: Language code for translated fields (e.g., 'fi_FI', 'en_US').
+                    Overrides the global ODOO_LOCALE setting for this call.
 
             Returns:
                 Created record details with ID, URL, and confirmation.
             """
-            result = await self._handle_create_record_tool(model, values, ctx)
+            result = await self._handle_create_record_tool(model, values, ctx, lang=lang)
             return CreateResult(**result)
 
         @self.app.tool(
@@ -516,6 +528,7 @@ class OdooToolHandler:
             model: str,
             record_id: int,
             values: Dict[str, Any],
+            lang: Optional[str] = None,
             ctx: Optional[Context] = None,
         ) -> UpdateResult:
             """Update an existing record.
@@ -524,11 +537,15 @@ class OdooToolHandler:
                 model: The Odoo model name (e.g., 'res.partner')
                 record_id: The record ID to update
                 values: Field values to update
+                lang: Language code for translated fields (e.g., 'fi_FI', 'en_US').
+                    Overrides the global ODOO_LOCALE setting for this call.
+                    Use this to write translations: update with lang='fi_FI' writes
+                    to the Finnish translation of translated fields.
 
             Returns:
                 Updated record details with confirmation.
             """
-            result = await self._handle_update_record_tool(model, record_id, values, ctx)
+            result = await self._handle_update_record_tool(model, record_id, values, ctx, lang=lang)
             return UpdateResult(**result)
 
         @self.app.tool(
@@ -566,6 +583,7 @@ class OdooToolHandler:
         offset: int,
         order: Optional[str],
         ctx=None,
+        lang: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Handle search tool request."""
         try:
@@ -675,9 +693,12 @@ class OdooToolHandler:
                     logger.debug(f"Fetching all fields for {model} search")
 
                 # Read records
+                lang_context = {"lang": lang} if lang else None
                 records = []
                 if record_ids:
-                    records = self.connection.read(model, record_ids, fields_to_fetch)
+                    records = self.connection.read(
+                        model, record_ids, fields_to_fetch, context=lang_context
+                    )
                     # Process datetime fields in each record
                     records = [self._process_record_dates(record, model) for record in records]
                 await self._ctx_progress(ctx, 3, 3, f"Returning {len(records)} records")
@@ -705,6 +726,7 @@ class OdooToolHandler:
         record_id: int,
         fields: Optional[List[str]],
         ctx=None,
+        lang: Optional[str] = None,
     ) -> RecordResult:
         """Handle get record tool request."""
         try:
@@ -741,7 +763,10 @@ class OdooToolHandler:
                     logger.debug(f"Fetching specific fields for {model}: {fields}")
 
                 # Read the record
-                records = self.connection.read(model, [record_id], fields_to_fetch)
+                lang_context = {"lang": lang} if lang else None
+                records = self.connection.read(
+                    model, [record_id], fields_to_fetch, context=lang_context
+                )
 
                 if not records:
                     raise ValidationError(f"Record not found: {model} with ID {record_id}")
@@ -993,6 +1018,7 @@ class OdooToolHandler:
         model: str,
         values: Dict[str, Any],
         ctx=None,
+        lang: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Handle create record tool request."""
         try:
@@ -1010,7 +1036,8 @@ class OdooToolHandler:
                     raise ValidationError("No values provided for record creation")
 
                 # Create the record
-                record_id = self.connection.create(model, values)
+                lang_context = {"lang": lang} if lang else None
+                record_id = self.connection.create(model, values, context=lang_context)
 
                 # Return only essential fields to minimize context usage
                 # Users can use get_record if they need more fields
@@ -1053,6 +1080,7 @@ class OdooToolHandler:
         record_id: int,
         values: Dict[str, Any],
         ctx=None,
+        lang: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Handle update record tool request."""
         try:
@@ -1075,7 +1103,10 @@ class OdooToolHandler:
                     raise NotFoundError(f"Record not found: {model} with ID {record_id}")
 
                 # Update the record
-                success = self.connection.write(model, [record_id], values)
+                lang_context = {"lang": lang} if lang else None
+                success = self.connection.write(
+                    model, [record_id], values, context=lang_context
+                )
 
                 # Return only essential fields to minimize context usage
                 # Users can use get_record if they need more fields

--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -1172,9 +1172,7 @@ class OdooToolHandler:
 
                 # Update the record
                 lang_context = {"lang": lang} if lang else None
-                success = self.connection.write(
-                    model, [record_id], values, context=lang_context
-                )
+                success = self.connection.write(model, [record_id], values, context=lang_context)
 
                 # Return only essential fields to minimize context usage
                 # Users can use get_record if they need more fields
@@ -1307,9 +1305,7 @@ class OdooToolHandler:
                 return {
                     "translations": translations_data,
                     "translation_type": context_data.get("translation_type", "text"),
-                    "translation_show_source": context_data.get(
-                        "translation_show_source", True
-                    ),
+                    "translation_show_source": context_data.get("translation_show_source", True),
                     "view_info": view_info,
                 }
 
@@ -1318,9 +1314,7 @@ class OdooToolHandler:
         except Exception as e:
             logger.error(f"Error in read_view_translations tool: {e}")
             sanitized_msg = ErrorSanitizer.sanitize_message(str(e))
-            raise ValidationError(
-                f"Failed to read view translations: {sanitized_msg}"
-            ) from e
+            raise ValidationError(f"Failed to read view translations: {sanitized_msg}") from e
 
     async def _handle_update_view_translation(
         self,
@@ -1330,9 +1324,7 @@ class OdooToolHandler:
     ) -> Dict[str, Any]:
         """Handle update view translation tool request."""
         try:
-            with perf_logger.track_operation(
-                "tool_update_view_translation", model="ir.ui.view"
-            ):
+            with perf_logger.track_operation("tool_update_view_translation", model="ir.ui.view"):
                 await self._ctx_info(ctx, f"Updating translations for view {view_id}...")
 
                 if not self.connection.is_authenticated:
@@ -1382,9 +1374,7 @@ class OdooToolHandler:
         except Exception as e:
             logger.error(f"Error in update_view_translation tool: {e}")
             sanitized_msg = ErrorSanitizer.sanitize_message(str(e))
-            raise ValidationError(
-                f"Failed to update view translation: {sanitized_msg}"
-            ) from e
+            raise ValidationError(f"Failed to update view translation: {sanitized_msg}") from e
 
 
 def register_tools(

--- a/tests/test_fixes_integration.py
+++ b/tests/test_fixes_integration.py
@@ -186,7 +186,7 @@ class TestFixesIntegration:
 
         # Verify read was called with the specific fields
         tool_handler.connection.read.assert_called_once_with(
-            "res.partner", [1], ["name", "vat", "create_date"]
+            "res.partner", [1], ["name", "vat", "create_date"], context=None
         )
 
         # Should still format datetime

--- a/tests/test_search_smart_defaults.py
+++ b/tests/test_search_smart_defaults.py
@@ -98,7 +98,9 @@ class TestSearchSmartDefaults:
         await handler("res.partner", [], fields, 10, 0, None)
 
         # Verify specified fields were used
-        tool_handler.connection.read.assert_called_once_with("res.partner", [1], fields)
+        tool_handler.connection.read.assert_called_once_with(
+            "res.partner", [1], fields, context=None
+        )
 
     @pytest.mark.asyncio
     async def test_search_with_all_fields(self, tool_handler):
@@ -126,7 +128,9 @@ class TestSearchSmartDefaults:
         await handler("res.partner", [], ["__all__"], 10, 0, None)
 
         # Verify None was passed to read (which means all fields)
-        tool_handler.connection.read.assert_called_once_with("res.partner", [1], None)
+        tool_handler.connection.read.assert_called_once_with(
+            "res.partner", [1], None, context=None
+        )
 
     @pytest.mark.asyncio
     async def test_search_falls_back_when_fields_get_fails(self, tool_handler):

--- a/tests/test_search_smart_defaults.py
+++ b/tests/test_search_smart_defaults.py
@@ -128,9 +128,7 @@ class TestSearchSmartDefaults:
         await handler("res.partner", [], ["__all__"], 10, 0, None)
 
         # Verify None was passed to read (which means all fields)
-        tool_handler.connection.read.assert_called_once_with(
-            "res.partner", [1], None, context=None
-        )
+        tool_handler.connection.read.assert_called_once_with("res.partner", [1], None, context=None)
 
     @pytest.mark.asyncio
     async def test_search_falls_back_when_fields_get_fails(self, tool_handler):

--- a/tests/test_smart_fields.py
+++ b/tests/test_smart_fields.py
@@ -240,7 +240,9 @@ class TestSmartFieldSelection:
         assert result.metadata is None
 
         # Should have called read with None (all fields)
-        tool_handler.connection.read.assert_called_once_with("res.partner", [1], None)
+        tool_handler.connection.read.assert_called_once_with(
+            "res.partner", [1], None, context=None
+        )
 
     @pytest.mark.asyncio
     async def test_get_record_with_specific_fields(self, tool_handler):
@@ -259,7 +261,9 @@ class TestSmartFieldSelection:
         assert result.metadata is None
 
         # Should have called read with specific fields
-        tool_handler.connection.read.assert_called_once_with("res.partner", [1], fields)
+        tool_handler.connection.read.assert_called_once_with(
+            "res.partner", [1], fields, context=None
+        )
 
     def test_field_selection(self, tool_handler):
         """Test that expected fields are selected by smart defaults."""

--- a/tests/test_smart_fields.py
+++ b/tests/test_smart_fields.py
@@ -240,9 +240,7 @@ class TestSmartFieldSelection:
         assert result.metadata is None
 
         # Should have called read with None (all fields)
-        tool_handler.connection.read.assert_called_once_with(
-            "res.partner", [1], None, context=None
-        )
+        tool_handler.connection.read.assert_called_once_with("res.partner", [1], None, context=None)
 
     @pytest.mark.asyncio
     async def test_get_record_with_specific_fields(self, tool_handler):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -337,7 +337,9 @@ class TestOdooToolHandler:
         assert result.total == 1
 
         # Verify fields were parsed correctly
-        mock_connection.read.assert_called_with("res.partner", [15], ["name", "is_company", "id"])
+        mock_connection.read.assert_called_with(
+            "res.partner", [15], ["name", "is_company", "id"], context=None
+        )
 
     @pytest.mark.asyncio
     async def test_search_records_with_complex_domain(
@@ -402,7 +404,9 @@ class TestOdooToolHandler:
 
         # Verify calls
         mock_access_controller.validate_model_access.assert_called_once_with("res.partner", "read")
-        mock_connection.read.assert_called_once_with("res.partner", [123], ["name", "email"])
+        mock_connection.read.assert_called_once_with(
+            "res.partner", [123], ["name", "email"], context=None
+        )
 
     @pytest.mark.asyncio
     async def test_get_record_not_found(
@@ -1003,7 +1007,9 @@ class TestCreateRecordTool:
         assert result.url == "http://localhost:8069/odoo/res.partner/42"
         assert "42" in result.message
 
-        mock_connection.create.assert_called_once_with("res.partner", {"name": "New Partner"})
+        mock_connection.create.assert_called_once_with(
+            "res.partner", {"name": "New Partner"}, context=None
+        )
         mock_connection.read.assert_called_once_with("res.partner", [42], ["id", "display_name"])
 
     @pytest.mark.asyncio
@@ -1112,7 +1118,7 @@ class TestUpdateRecordTool:
         mock_connection.read.assert_any_call("res.partner", [10], ["id"])
         mock_connection.read.assert_any_call("res.partner", [10], ["id", "display_name"])
         mock_connection.write.assert_called_once_with(
-            "res.partner", [10], {"name": "Updated Partner"}
+            "res.partner", [10], {"name": "Updated Partner"}, context=None
         )
 
     @pytest.mark.asyncio

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -83,6 +83,8 @@ class TestOdooToolHandler:
             "update_record",
             "delete_record",
             "list_resource_templates",
+            "read_view_translations",
+            "update_view_translation",
         }
         assert set(mock_app._tools.keys()) == expected_tools
 

--- a/tests/test_view_translations.py
+++ b/tests/test_view_translations.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock
 import pytest
 from mcp.server.fastmcp import FastMCP
 
-from mcp_server_odoo.config import OdooConfig
 from mcp_server_odoo.access_control import AccessController
+from mcp_server_odoo.config import OdooConfig
 from mcp_server_odoo.error_handling import ValidationError
 from mcp_server_odoo.odoo_connection import OdooConnection
 from mcp_server_odoo.tools import OdooToolHandler
@@ -78,7 +78,13 @@ class TestViewTranslationTools:
         )
         # Mock read for view metadata
         mock_connection.read.return_value = [
-            {"id": 42, "name": "Test View", "key": "website.test_view", "write_date": "2026-03-28 10:00:00", "write_uid": [9, "Admin"]}
+            {
+                "id": 42,
+                "name": "Test View",
+                "key": "website.test_view",
+                "write_date": "2026-03-28 10:00:00",
+                "write_uid": [9, "Admin"],
+            }
         ]
 
         read_view_translations = mock_app._tools["read_view_translations"]
@@ -92,8 +98,7 @@ class TestViewTranslationTools:
 
         # Verify execute_kw was called correctly
         mock_connection.execute_kw.assert_called_once_with(
-            "ir.ui.view", "get_field_translations",
-            [[42], "arch_db"], {"langs": ["en_US", "fi_FI"]}
+            "ir.ui.view", "get_field_translations", [[42], "arch_db"], {"langs": ["en_US", "fi_FI"]}
         )
 
     @pytest.mark.asyncio
@@ -104,20 +109,27 @@ class TestViewTranslationTools:
             {"translation_type": "text", "translation_show_source": True},
         )
         mock_connection.read.return_value = [
-            {"id": 10, "name": "View", "key": "website.view", "write_date": "2026-03-28", "write_uid": [1, "Admin"]}
+            {
+                "id": 10,
+                "name": "View",
+                "key": "website.view",
+                "write_date": "2026-03-28",
+                "write_uid": [1, "Admin"],
+            }
         ]
 
         read_view_translations = mock_app._tools["read_view_translations"]
-        result = await read_view_translations(view_id=10)
+        await read_view_translations(view_id=10)
 
         # Should not pass langs kwarg when None
         mock_connection.execute_kw.assert_called_once_with(
-            "ir.ui.view", "get_field_translations",
-            [[10], "arch_db"], {}
+            "ir.ui.view", "get_field_translations", [[10], "arch_db"], {}
         )
 
     @pytest.mark.asyncio
-    async def test_read_view_translations_not_authenticated(self, handler, mock_connection, mock_app):
+    async def test_read_view_translations_not_authenticated(
+        self, handler, mock_connection, mock_app
+    ):
         """Test read_view_translations when not authenticated."""
         mock_connection.is_authenticated = False
 
@@ -142,9 +154,10 @@ class TestViewTranslationTools:
         assert "fi_FI" in result.message
 
         mock_connection.execute_kw.assert_called_once_with(
-            "ir.ui.view", "update_field_translations",
+            "ir.ui.view",
+            "update_field_translations",
             [[42], "arch_db", {"fi_FI": {"Contact Us": "Ota yhteytta", "Learn More": "Lue lisaa"}}],
-            {}
+            {},
         )
 
     @pytest.mark.asyncio
@@ -172,14 +185,18 @@ class TestViewTranslationTools:
             await update_view_translation(view_id=42, translations={})
 
     @pytest.mark.asyncio
-    async def test_update_view_translation_invalid_structure(self, handler, mock_connection, mock_app):
+    async def test_update_view_translation_invalid_structure(
+        self, handler, mock_connection, mock_app
+    ):
         """Test update_view_translation with invalid translation structure."""
         update_view_translation = mock_app._tools["update_view_translation"]
         with pytest.raises(ValidationError, match="must be a dict"):
             await update_view_translation(view_id=42, translations={"fi_FI": "not a dict"})
 
     @pytest.mark.asyncio
-    async def test_update_view_translation_not_authenticated(self, handler, mock_connection, mock_app):
+    async def test_update_view_translation_not_authenticated(
+        self, handler, mock_connection, mock_app
+    ):
         """Test update_view_translation when not authenticated."""
         mock_connection.is_authenticated = False
 

--- a/tests/test_view_translations.py
+++ b/tests/test_view_translations.py
@@ -1,0 +1,191 @@
+"""Test suite for view translation MCP tools."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from mcp_server_odoo.config import OdooConfig
+from mcp_server_odoo.access_control import AccessController
+from mcp_server_odoo.error_handling import ValidationError
+from mcp_server_odoo.odoo_connection import OdooConnection
+from mcp_server_odoo.tools import OdooToolHandler
+
+
+class TestViewTranslationTools:
+    """Test cases for read_view_translations and update_view_translation tools."""
+
+    @pytest.fixture
+    def mock_app(self):
+        """Create a mock FastMCP app."""
+        app = MagicMock(spec=FastMCP)
+        app._tools = {}
+
+        def tool_decorator(**kwargs):
+            def decorator(func):
+                app._tools[func.__name__] = func
+                return func
+
+            return decorator
+
+        app.tool = tool_decorator
+        return app
+
+    @pytest.fixture
+    def mock_connection(self):
+        """Create a mock OdooConnection."""
+        connection = MagicMock(spec=OdooConnection)
+        connection.is_authenticated = True
+        return connection
+
+    @pytest.fixture
+    def mock_access_controller(self):
+        """Create a mock AccessController."""
+        controller = MagicMock(spec=AccessController)
+        return controller
+
+    @pytest.fixture
+    def valid_config(self):
+        """Create a valid config."""
+        return OdooConfig(
+            url="http://localhost:8069",
+            api_key="test_api_key",
+            database="test_db",
+            default_limit=10,
+            max_limit=100,
+        )
+
+    @pytest.fixture
+    def handler(self, mock_app, mock_connection, mock_access_controller, valid_config):
+        """Create an OdooToolHandler instance."""
+        return OdooToolHandler(mock_app, mock_connection, mock_access_controller, valid_config)
+
+    def test_translation_tools_registered(self, handler, mock_app):
+        """Test that translation tools are registered with FastMCP."""
+        assert "read_view_translations" in mock_app._tools
+        assert "update_view_translation" in mock_app._tools
+
+    @pytest.mark.asyncio
+    async def test_read_view_translations_success(self, handler, mock_connection, mock_app):
+        """Test successful read_view_translations with language filter."""
+        # Mock execute_kw for get_field_translations
+        mock_connection.execute_kw.return_value = (
+            [
+                {"lang": "en_US", "source": "Contact Us", "value": "Contact Us"},
+                {"lang": "fi_FI", "source": "Contact Us", "value": "Ota yhteytta"},
+            ],
+            {"translation_type": "text", "translation_show_source": True},
+        )
+        # Mock read for view metadata
+        mock_connection.read.return_value = [
+            {"id": 42, "name": "Test View", "key": "website.test_view", "write_date": "2026-03-28 10:00:00", "write_uid": [9, "Admin"]}
+        ]
+
+        read_view_translations = mock_app._tools["read_view_translations"]
+        result = await read_view_translations(view_id=42, langs=["en_US", "fi_FI"])
+
+        # Verify the result is a ViewTranslationsResult
+        assert len(result.translations) == 2
+        assert result.translation_type == "text"
+        assert result.translation_show_source is True
+        assert result.view_info["name"] == "Test View"
+
+        # Verify execute_kw was called correctly
+        mock_connection.execute_kw.assert_called_once_with(
+            "ir.ui.view", "get_field_translations",
+            [[42], "arch_db"], {"langs": ["en_US", "fi_FI"]}
+        )
+
+    @pytest.mark.asyncio
+    async def test_read_view_translations_no_langs(self, handler, mock_connection, mock_app):
+        """Test read_view_translations without language filter (all installed)."""
+        mock_connection.execute_kw.return_value = (
+            [{"lang": "en_US", "source": "Hello", "value": "Hello"}],
+            {"translation_type": "text", "translation_show_source": True},
+        )
+        mock_connection.read.return_value = [
+            {"id": 10, "name": "View", "key": "website.view", "write_date": "2026-03-28", "write_uid": [1, "Admin"]}
+        ]
+
+        read_view_translations = mock_app._tools["read_view_translations"]
+        result = await read_view_translations(view_id=10)
+
+        # Should not pass langs kwarg when None
+        mock_connection.execute_kw.assert_called_once_with(
+            "ir.ui.view", "get_field_translations",
+            [[10], "arch_db"], {}
+        )
+
+    @pytest.mark.asyncio
+    async def test_read_view_translations_not_authenticated(self, handler, mock_connection, mock_app):
+        """Test read_view_translations when not authenticated."""
+        mock_connection.is_authenticated = False
+
+        read_view_translations = mock_app._tools["read_view_translations"]
+        with pytest.raises(ValidationError, match="Not authenticated"):
+            await read_view_translations(view_id=42)
+
+    @pytest.mark.asyncio
+    async def test_update_view_translation_success(self, handler, mock_connection, mock_app):
+        """Test successful update_view_translation."""
+        mock_connection.execute_kw.return_value = True
+
+        update_view_translation = mock_app._tools["update_view_translation"]
+        result = await update_view_translation(
+            view_id=42,
+            translations={"fi_FI": {"Contact Us": "Ota yhteytta", "Learn More": "Lue lisaa"}},
+        )
+
+        assert result.success is True
+        assert result.updated_langs == ["fi_FI"]
+        assert "2" in result.message  # 2 terms
+        assert "fi_FI" in result.message
+
+        mock_connection.execute_kw.assert_called_once_with(
+            "ir.ui.view", "update_field_translations",
+            [[42], "arch_db", {"fi_FI": {"Contact Us": "Ota yhteytta", "Learn More": "Lue lisaa"}}],
+            {}
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_view_translation_multiple_langs(self, handler, mock_connection, mock_app):
+        """Test updating multiple languages at once."""
+        mock_connection.execute_kw.return_value = True
+
+        update_view_translation = mock_app._tools["update_view_translation"]
+        result = await update_view_translation(
+            view_id=42,
+            translations={
+                "fi_FI": {"Hello": "Hei"},
+                "de_DE": {"Hello": "Hallo"},
+            },
+        )
+
+        assert result.success is True
+        assert set(result.updated_langs) == {"fi_FI", "de_DE"}
+
+    @pytest.mark.asyncio
+    async def test_update_view_translation_empty(self, handler, mock_connection, mock_app):
+        """Test update_view_translation with empty translations dict."""
+        update_view_translation = mock_app._tools["update_view_translation"]
+        with pytest.raises(ValidationError, match="No translations provided"):
+            await update_view_translation(view_id=42, translations={})
+
+    @pytest.mark.asyncio
+    async def test_update_view_translation_invalid_structure(self, handler, mock_connection, mock_app):
+        """Test update_view_translation with invalid translation structure."""
+        update_view_translation = mock_app._tools["update_view_translation"]
+        with pytest.raises(ValidationError, match="must be a dict"):
+            await update_view_translation(view_id=42, translations={"fi_FI": "not a dict"})
+
+    @pytest.mark.asyncio
+    async def test_update_view_translation_not_authenticated(self, handler, mock_connection, mock_app):
+        """Test update_view_translation when not authenticated."""
+        mock_connection.is_authenticated = False
+
+        update_view_translation = mock_app._tools["update_view_translation"]
+        with pytest.raises(ValidationError, match="Not authenticated"):
+            await update_view_translation(
+                view_id=42,
+                translations={"fi_FI": {"Hello": "Hei"}},
+            )

--- a/tests/test_write_tools.py
+++ b/tests/test_write_tools.py
@@ -77,7 +77,7 @@ class TestWriteTools:
             == f"http://localhost:8069/web#id={created_id}&model={model}&view_type=form"
         )
         assert "Successfully created" in result["message"]
-        mock_connection.create.assert_called_once_with(model, values)
+        mock_connection.create.assert_called_once_with(model, values, context=None)
         mock_connection.read.assert_called_once_with(model, [created_id], ["id", "display_name"])
 
     @pytest.mark.asyncio
@@ -130,7 +130,7 @@ class TestWriteTools:
             == f"http://localhost:8069/web#id={record_id}&model={model}&view_type=form"
         )
         assert "Successfully updated" in result["message"]
-        mock_connection.write.assert_called_once_with(model, [record_id], values)
+        mock_connection.write.assert_called_once_with(model, [record_id], values, context=None)
         # Verify both read calls with correct parameters
         expected_calls = [
             call(model, [record_id], ["id"]),  # Existence check


### PR DESCRIPTION
## Summary
- Add `read_view_translations` tool that reads per-language translation terms from `ir.ui.view.arch_db` using Odoo's `get_field_translations` API
- Add `update_view_translation` tool that safely updates individual language terms without corrupting other translations, using Odoo's `update_field_translations` API
- These tools bypass the ORM `arch` write mechanism which rewrites all language versions via heuristic term mapping and can corrupt translations

## Background

Odoo's `ir.ui.view.arch_db` is a JSONB column with per-language keys (`{"en_US": "...", "fi_FI": "..."}`). The field uses `translate=xml_translate` (a callable), making it a "model_terms" translated field.

**The problem:** Writing via the standard ORM `write()` triggers the translation mechanism in `odoo/orm/fields_textual.py` (lines 327-392) which:

1. Takes the new value for the **current language** (literal replacement)
2. Rebuilds **all other languages** by applying a heuristic term mapping (`get_close_matches` with 0.9 threshold) from old terms to new XML structure
3. If terms changed or don't match, other languages lose their translations (get `None`)

This is a known, long-standing Odoo issue affecting versions 16, 17, and 19:
- [odoo/odoo#162763](https://github.com/odoo/odoo/issues/162763) — "Origin HTML/XML becomes overwritten if a translation is created in EN(US)" (open)
- [odoo/odoo#124124](https://github.com/odoo/odoo/issues/124124) — related earlier report
- [odoo/odoo#150829](https://github.com/odoo/odoo/issues/150829) — related earlier report

**Verified against latest Odoo 19 source** (pulled 2026-03-30): the behavior is unchanged, `fields_textual.py` still rewrites all languages on every write.

**The solution:** Use Odoo's built-in public methods `get_field_translations` and `update_field_translations` which operate at the individual term level and only modify the specified languages, completely bypassing the destructive write path.

## New tools

### `read_view_translations(view_id, langs?)`
Calls `ir.ui.view.get_field_translations()` via XML-RPC. Returns all translatable terms with their source (en_US) and translated values per language, plus view metadata.

### `update_view_translation(view_id, translations)`
Calls `ir.ui.view.update_field_translations()` via XML-RPC. Takes `{lang: {source_term: new_translation}}` and updates only the specified terms in the specified languages. Other languages and unspecified terms remain untouched.

## Test plan
- [x] 9 new unit tests in `tests/test_view_translations.py` (all passing)
- [x] Existing 54 tests still pass (63 total)
- [x] Live-tested against production Odoo 19: `get_field_translations` returns correct per-language terms (e.g., `'Thank You!' → 'Kiitos!'`)
- [x] Verified Odoo source code trace: confirmed the destructive write path in `fields_textual.py:375-378`
- [ ] Manual verification: use `read_view_translations` → `update_view_translation` workflow on a test view