### PR TITLE
Add Beacon Agent Manifest for AI agent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCP Server for Odoo
 
+[![Beacon Verified](https://registry-ruby.vercel.app/api/v1/agents/ivnvxd%2Fmcp-server-odoo/badge.svg)](https://portal-five-phi-54.vercel.app/?q=odoo+mcp)
+
 [![CI](https://github.com/ivnvxd/mcp-server-odoo/actions/workflows/ci.yml/badge.svg)](https://github.com/ivnvxd/mcp-server-odoo/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/ivnvxd/mcp-server-odoo/branch/main/graph/badge.svg)](https://codecov.io/gh/ivnvxd/mcp-server-odoo)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)

--- a/beacon.json
+++ b/beacon.json
@@ -1,0 +1,12 @@
+{
+  "beacon_manifest": "0.1",
+  "id": "ivnvxd/mcp-server-odoo",
+  "name": "MCP Server for Odoo",
+  "description": "MCP server for AI assistants to query and manage Odoo ERP data via natural language.",
+  "capabilities": ["mcp-server", "erp", "odoo", "business-data", "crm"],
+  "interfaces": [
+    { "type": "mcp", "endpoint": "https://github.com/ivnvxd/mcp-server-odoo" }
+  ],
+  "source": "https://github.com/ivnvxd/mcp-server-odoo",
+  "homepage": "https://github.com/ivnvxd/mcp-server-odoo"
+}


### PR DESCRIPTION
## Beacon Agent Manifest (optional, ~2 min review)

[Beacon](https://portal-five-phi-54.vercel.app) is an open agent registry (33k+ MCP servers & agents). You are already indexed from GitHub.

This PR adds:
- **`beacon.json`** — [open v0.1 standard](https://github.com/enrichgateagent-png/beacon-agent-manifest) for machine-readable agent discovery (Claude, Cursor MCP, etc.)
- **README badge** — live verification link back to your listing

No API keys, no accounts. Hosting `beacon.json` in your repo is the verification (location = proof).

If merged, Beacon auto-upgrades your listing to **verified manifest** on the next scan.

Spec: https://github.com/enrichgateagent-png/beacon-agent-manifest · [llms.txt](https://registry-ruby.vercel.app/llms.txt)