### PR TITLE
Add opt-in per-request API-key auth for streamable-http (ODOO_MCP_PER_REQUEST_AUTH)

### DIFF
--- a/mcp_server_odoo/config.py
+++ b/mcp_server_odoo/config.py
@@ -45,6 +45,14 @@ class OdooConfig:
     # task, server instance) in the session manager until process restart.
     session_idle_timeout: Optional[float] = None
 
+    # Per-request authentication (streamable-http). When true, no server-wide
+    # ODOO_API_KEY is used; each HTTP request carries its own key
+    # (Authorization: Bearer <key>) and runs as that key's Odoo user. Data
+    # calls go over standard XML-RPC as the resolved user, so Odoo's own
+    # access rights and record rules are the per-user boundary. Requires the
+    # small /mcp/auth/validate endpoint (key -> user id) to be served by Odoo.
+    per_request_auth: bool = False
+
     # YOLO mode configuration
     yolo_mode: str = "off"  # "off", "read", or "true"
 
@@ -76,8 +84,21 @@ class OdooConfig:
         has_api_key = bool(self.api_key)
         has_credentials = bool(self.username and self.password)
 
+        # Per-request auth takes precedence: the server holds no credentials of
+        # its own, so no startup key/password is required. Each request supplies
+        # its own key. It does need an explicit database (auto-detect would need
+        # a database listing, which is disabled on locked-down servers).
+        if self.per_request_auth:
+            if self.transport != "streamable-http":
+                raise ValueError(
+                    "ODOO_MCP_PER_REQUEST_AUTH requires ODOO_MCP_TRANSPORT=streamable-http"
+                )
+            if self.is_yolo_enabled:
+                raise ValueError("ODOO_MCP_PER_REQUEST_AUTH cannot be combined with ODOO_YOLO")
+            if not self.database:
+                raise ValueError("ODOO_MCP_PER_REQUEST_AUTH requires ODOO_DB to be set")
         # In YOLO mode, we might need username even with API key for standard auth
-        if self.is_yolo_enabled:
+        elif self.is_yolo_enabled:
             if not has_credentials and not (has_api_key and self.username):
                 raise ValueError("YOLO mode requires either username/password or username/API key")
         else:
@@ -159,8 +180,10 @@ class OdooConfig:
         Returns:
             Dict[str, str]: Mapping of endpoint names to paths
         """
-        if self.is_yolo_enabled:
-            # Use standard Odoo endpoints in YOLO mode
+        if self.is_yolo_enabled or self.per_request_auth:
+            # Standard Odoo endpoints. YOLO needs no module at all; per-request
+            # auth resolves the user via /mcp/auth/validate but runs data calls
+            # over standard XML-RPC as that user (Odoo enforces their rights).
             return {"db": "/xmlrpc/db", "common": "/xmlrpc/2/common", "object": "/xmlrpc/2/object"}
         else:
             # DB endpoint is always server-wide; common/object use MCP routes
@@ -285,6 +308,7 @@ def load_config(env_file: Optional[Path] = None) -> OdooConfig:
         yolo_mode=get_yolo_mode(),
         enable_method_calls=get_bool_env("ODOO_MCP_ENABLE_METHOD_CALLS", False),
         allowed_hosts=parse_allowed_hosts(),
+        per_request_auth=get_bool_env("ODOO_MCP_PER_REQUEST_AUTH", False),
     )
 
     return config

--- a/mcp_server_odoo/request_auth.py
+++ b/mcp_server_odoo/request_auth.py
@@ -75,6 +75,8 @@ def _require_key() -> str:
 
 def _request_config(key: str) -> OdooConfig:
     """A shallow copy of the base config carrying this request's key."""
+    if _base_config is None:
+        raise PerRequestAuthError("Per-request auth is not configured")
     cfg = copy.copy(_base_config)
     cfg.api_key = key
     cfg.username = None

--- a/mcp_server_odoo/request_auth.py
+++ b/mcp_server_odoo/request_auth.py
@@ -1,0 +1,233 @@
+"""Per-request authentication for the streamable-http transport.
+
+In per-request mode the server holds no credentials of its own. Each HTTP
+request carries its own Odoo API key in the ``Authorization: Bearer <key>``
+header (``X-API-Key`` is also accepted). An ASGI middleware pulls that key into
+a context variable and every Odoo access for that request runs as the key's
+user, over a short-lived connection that is discarded when the request ends.
+
+Design notes:
+
+* **Stateless per request.** No connection pool or auth cache spans requests.
+  Within a single request the connection/controller are built once and reused
+  (stored in context variables), then closed in ``reset()``.
+* **Fail-closed.** There is no shared, server-wide connection to fall back to.
+  Any Odoo access outside a request context (no key in the contextvar) raises,
+  so a missed call site fails loudly instead of leaking a shared identity.
+* **Header, not tool Context.** The middleware is the one place that can both
+  populate the contextvar for tools *and* resources and return a real HTTP 401
+  before the request is dispatched to the MCP server.
+
+This module is a no-op unless ``ODOO_MCP_PER_REQUEST_AUTH`` is enabled.
+"""
+
+import contextvars
+import copy
+import logging
+from typing import Callable, Optional
+
+from .access_control import AccessController
+from .config import OdooConfig
+from .odoo_connection import OdooConnection, OdooConnectionError
+
+logger = logging.getLogger(__name__)
+
+# The raw API key for the request currently being handled. Default None means
+# "no request context" — any attempt to build a connection then fails closed.
+current_api_key: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "current_api_key", default=None
+)
+
+# Per-request memoization so the connection/controller are built once per
+# request rather than once per attribute access. Never spans requests.
+_current_connection: contextvars.ContextVar[Optional[OdooConnection]] = contextvars.ContextVar(
+    "_current_connection", default=None
+)
+_current_access_controller: contextvars.ContextVar[Optional[AccessController]] = (
+    contextvars.ContextVar("_current_access_controller", default=None)
+)
+
+# Configured once at server startup.
+_base_config: Optional[OdooConfig] = None
+_performance_manager = None
+
+
+class PerRequestAuthError(OdooConnectionError):
+    """Raised when an Odoo access is attempted without a request API key."""
+
+
+def configure(base_config: OdooConfig, performance_manager) -> None:
+    """Wire the base config and shared performance manager used per request."""
+    global _base_config, _performance_manager
+    _base_config = base_config
+    _performance_manager = performance_manager
+
+
+def _require_key() -> str:
+    key = current_api_key.get()
+    if not key:
+        raise PerRequestAuthError(
+            "No API key in the request context. Per-request auth requires an "
+            "'Authorization: Bearer <key>' header on every request."
+        )
+    return key
+
+
+def _request_config(key: str) -> OdooConfig:
+    """A shallow copy of the base config carrying this request's key."""
+    cfg = copy.copy(_base_config)
+    cfg.api_key = key
+    cfg.username = None
+    cfg.password = None
+    cfg.per_request_auth = True
+    return cfg
+
+
+def get_connection() -> OdooConnection:
+    """Return the connection for the current request, building it on first use.
+
+    Fails closed if there is no API key in the request context.
+    """
+    if _base_config is None:
+        raise PerRequestAuthError("Per-request auth is not configured")
+    conn = _current_connection.get()
+    if conn is not None:
+        return conn
+    key = _require_key()
+    conn = OdooConnection(_request_config(key), performance_manager=_performance_manager)
+    conn.connect()
+    conn.authenticate()
+    _current_connection.set(conn)
+    return conn
+
+
+def get_access_controller() -> AccessController:
+    """Return the access controller for the current request (built on first use)."""
+    if _base_config is None:
+        raise PerRequestAuthError("Per-request auth is not configured")
+    ac = _current_access_controller.get()
+    if ac is not None:
+        return ac
+    conn = get_connection()
+    ac = AccessController(
+        _request_config(_require_key()),
+        database=conn.database,
+        auth_method=conn.auth_method,
+    )
+    _current_access_controller.set(ac)
+    return ac
+
+
+def reset() -> None:
+    """Tear down and clear all per-request state. Called in the middleware's
+    ``finally`` so a reused worker task never inherits a previous request's
+    key or connection."""
+    conn = _current_connection.get()
+    if conn is not None:
+        try:
+            conn.disconnect(suppress_logging=True)
+        except Exception:  # noqa: BLE001 - cleanup must never raise
+            pass
+    _current_connection.set(None)
+    _current_access_controller.set(None)
+    current_api_key.set(None)
+
+
+class _PerRequestProxy:
+    """Transparent stand-in for the connection / access controller.
+
+    Registered handlers keep calling ``self.connection.<x>`` /
+    ``self.access_controller.<x>``; every access is routed to the object built
+    for the current request. Holds no state of its own.
+    """
+
+    __slots__ = ("_resolver",)
+
+    def __init__(self, resolver: Callable[[], object]):
+        object.__setattr__(self, "_resolver", resolver)
+
+    def __getattr__(self, name):
+        return getattr(self._resolver(), name)
+
+
+def connection_proxy() -> "_PerRequestProxy":
+    return _PerRequestProxy(get_connection)
+
+
+def access_controller_proxy() -> "_PerRequestProxy":
+    return _PerRequestProxy(get_access_controller)
+
+
+def _extract_key(headers: list) -> Optional[str]:
+    """Pull the API key from an ASGI raw headers list.
+
+    Accepts ``Authorization: Bearer <key>`` (preferred) or ``X-API-Key: <key>``.
+    """
+    auth = None
+    x_api_key = None
+    for name, value in headers:
+        lname = name.decode("latin-1").lower()
+        if lname == "authorization":
+            auth = value.decode("latin-1")
+        elif lname == "x-api-key":
+            x_api_key = value.decode("latin-1")
+    if auth:
+        parts = auth.split(None, 1)
+        if len(parts) == 2 and parts[0].lower() == "bearer" and parts[1].strip():
+            return parts[1].strip()
+        return None  # malformed Authorization header
+    if x_api_key and x_api_key.strip():
+        return x_api_key.strip()
+    return None
+
+
+class PerRequestAuthMiddleware:
+    """ASGI middleware that gates the MCP endpoint on a per-request API key.
+
+    Missing/malformed credentials get a real HTTP 401 before the request ever
+    reaches the MCP server. The contextvar is always cleared in ``finally`` so
+    no key bleeds across requests on a reused task.
+    """
+
+    def __init__(self, app, guarded_prefix: str = "/mcp"):
+        self.app = app
+        self.guarded_prefix = guarded_prefix
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if not path.startswith(self.guarded_prefix):
+            # Unguarded (e.g. GET /health): pass through untouched.
+            await self.app(scope, receive, send)
+            return
+
+        key = _extract_key(scope.get("headers", []))
+        if not key:
+            await self._unauthorized(send)
+            return
+
+        token = current_api_key.set(key)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            current_api_key.reset(token)
+            reset()
+
+    @staticmethod
+    async def _unauthorized(send):
+        body = b'{"error":"unauthorized","message":"Missing or malformed Authorization: Bearer <api-key> header"}'
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 401,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode()),
+                    (b"www-authenticate", b'Bearer realm="odoo-mcp"'),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -6,7 +6,7 @@ and functionality through the Model Context Protocol.
 
 import asyncio
 import contextlib
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 from mcp.server import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
@@ -114,8 +114,10 @@ class OdooMCPServer:
         """
         self.performance_manager = PerformanceManager(self.config)
         request_auth.configure(self.config, self.performance_manager)
-        self.connection = request_auth.connection_proxy()
-        self.access_controller = request_auth.access_controller_proxy()
+        # The proxies duck-type the real objects (attribute access resolves
+        # against the per-request instance), hence the casts.
+        self.connection = cast(OdooConnection, request_auth.connection_proxy())
+        self.access_controller = cast(AccessController, request_auth.access_controller_proxy())
         self._register_resources()
         self._register_tools()
         logger.info("Per-request auth enabled: each request authenticates with its own API key")

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -24,6 +24,7 @@ from .odoo_connection import OdooConnection, OdooConnectionError
 from .performance import PerformanceManager
 from .resources import register_resources
 from .tools import register_tools
+from . import request_auth
 
 # Set up logging
 logger = get_logger(__name__)
@@ -99,7 +100,26 @@ class OdooMCPServer:
                 return Completion(values=matches[:20])
             return None
 
+        if self.config.per_request_auth:
+            self._setup_per_request_auth()
+
         logger.info(f"Initialized Odoo MCP Server v{SERVER_VERSION}")
+
+    def _setup_per_request_auth(self) -> None:
+        """Wire per-request auth: the connection and access controller become
+        proxies that resolve to the object built for the current request's key.
+
+        No server-wide connection is created (fail-closed): any Odoo access
+        outside a request context raises. Handlers are registered eagerly here
+        (pure app decoration, no I/O) so tools exist before the first request.
+        """
+        self.performance_manager = PerformanceManager(self.config)
+        request_auth.configure(self.config, self.performance_manager)
+        self.connection = request_auth.connection_proxy()
+        self.access_controller = request_auth.access_controller_proxy()
+        self._register_resources()
+        self._register_tools()
+        logger.info("Per-request auth enabled: each request authenticates with its own API key")
 
     @contextlib.asynccontextmanager
     async def _odoo_lifespan(self, app: FastMCP):
@@ -140,6 +160,10 @@ class OdooMCPServer:
             ConnectionError: If connection fails
             ConfigurationError: If configuration is invalid
         """
+        # Per-request auth holds no server-wide connection; each request builds
+        # and tears down its own. Nothing to establish at startup.
+        if self.config.per_request_auth:
+            return
         if self.connection and self.connection.is_authenticated:
             logger.info("Reusing existing authenticated Odoo connection")
             return
@@ -210,6 +234,10 @@ class OdooMCPServer:
 
     def _cleanup_connection(self):
         """Clean up Odoo connection."""
+        # Per-request connections are closed per request (request_auth.reset);
+        # self.connection is a proxy with no state to clean up here.
+        if self.config.per_request_auth:
+            return
         if self.connection:
             try:
                 logger.info("Closing Odoo connection...")
@@ -289,6 +317,9 @@ class OdooMCPServer:
             self._warn_if_exposed(host)
             self.app.settings.host = host
             self.app.settings.port = port
+            if self.config.per_request_auth:
+                await self._run_http_per_request(host, port)
+                return
             self._preseed_session_manager()
             await self.app.run_streamable_http_async()
         except KeyboardInterrupt:
@@ -298,6 +329,33 @@ class OdooMCPServer:
         except Exception as e:
             context = ErrorContext(operation="server_run_http")
             error_handler.handle_error(e, context=context)
+
+    async def _run_http_per_request(self, host: str, port: int) -> None:
+        """Serve streamable-http with per-request API-key auth.
+
+        Runs the transport STATELESS so each POST is handled inline in the
+        request task: this is what lets the API key set by the ASGI middleware
+        reach the tool through the context variable (a stateful session would
+        dispatch the tool on a separate long-lived task the header never
+        touches). The middleware also returns a real 401 before dispatch.
+        """
+        import uvicorn
+
+        # Stateless: no server-side session state between requests, so the
+        # per-request key set in middleware is visible to the inline handler.
+        self.app.settings.stateless_http = True
+        self.app.settings.json_response = True
+
+        http_app = self.app.streamable_http_app()
+        guarded = request_auth.PerRequestAuthMiddleware(http_app, guarded_prefix="/mcp")
+
+        config = uvicorn.Config(
+            guarded,
+            host=host,
+            port=port,
+            log_level=self.config.log_level.lower(),
+        )
+        await uvicorn.Server(config).serve()
 
     def _preseed_session_manager(self) -> None:
         """Apply ODOO_MCP_SESSION_IDLE_TIMEOUT to the streamable-http transport.
@@ -364,6 +422,21 @@ class OdooMCPServer:
         if host in ("localhost", "127.0.0.1", "::1"):
             return
 
+        if self.config.per_request_auth:
+            # Per-request auth DOES gate every request: no valid API key in the
+            # Authorization header -> HTTP 401 before dispatch. So the generic
+            # "no authentication" warning would be false here. Note the real
+            # residual risk instead: bearer tokens cross the network in the
+            # clear unless TLS terminates in front.
+            logger.info(
+                "HTTP transport binding to '%s' with per-request auth: every request "
+                "must carry a valid 'Authorization: Bearer <api-key>' (else 401). Keys "
+                "are Odoo credentials sent in the clear over plain HTTP — keep this on a "
+                "trusted network or terminate TLS in front.",
+                host,
+            )
+            return
+
         message = (
             f"HTTP transport binding to '{host}' — this transport has NO built-in "
             "authentication. Anyone who can reach this port gets Odoo access with "
@@ -400,6 +473,15 @@ class OdooMCPServer:
         Returns:
             Dict with health status
         """
+        if self.config.per_request_auth:
+            # No server-wide connection to probe; liveness is what /health means
+            # here. Touching the proxy outside a request would fail closed.
+            return {
+                "status": "healthy",
+                "version": SERVER_VERSION,
+                "connection": {"connected": True, "mode": "per-request-auth"},
+            }
+
         is_connected = bool(self.connection is not None and self.connection.is_authenticated)
 
         return {

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional
 from mcp.server import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
-from . import __version__
+from . import __version__, request_auth
 from .access_control import AccessController
 from .config import OdooConfig, get_config
 from .error_handling import (
@@ -24,7 +24,6 @@ from .odoo_connection import OdooConnection, OdooConnectionError
 from .performance import PerformanceManager
 from .resources import register_resources
 from .tools import register_tools
-from . import request_auth
 
 # Set up logging
 logger = get_logger(__name__)

--- a/tests/test_per_request_auth.py
+++ b/tests/test_per_request_auth.py
@@ -8,6 +8,8 @@ exercised separately against a real Odoo + cubert_mcp addon.
 """
 
 import asyncio
+from contextlib import contextmanager
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -185,3 +187,121 @@ def test_middleware_passes_through_unguarded_path():
     _run(go())
     assert downstream.called is True  # /health not gated
     assert sent == []  # no 401 emitted
+
+
+# --------------------------------------------------------------------------- #
+# Per-request config, connection and controller lifecycle
+# --------------------------------------------------------------------------- #
+@contextmanager
+def _configured(cfg=None, key="req-key"):
+    """Configure the module for one test; restore pristine state after."""
+    prev_cfg = request_auth._base_config
+    prev_pm = request_auth._performance_manager
+    request_auth.configure(cfg or _cfg(), performance_manager=Mock())
+    token = current_api_key.set(key) if key else None
+    try:
+        yield
+    finally:
+        request_auth.reset()
+        if token is not None:
+            current_api_key.reset(token)
+        request_auth._base_config = prev_cfg
+        request_auth._performance_manager = prev_pm
+
+
+def test_request_config_carries_key_and_drops_credentials():
+    base = _cfg()
+    with _configured(base, key=None):
+        cfg = request_auth._request_config("k-abc")
+    assert cfg is not base  # a copy: the base config is never mutated
+    assert cfg.api_key == "k-abc"
+    assert cfg.username is None
+    assert cfg.password is None
+    assert cfg.per_request_auth is True
+    assert base.api_key is None
+
+
+def test_request_config_unconfigured_fails_closed():
+    prev = request_auth._base_config
+    request_auth._base_config = None
+    try:
+        with pytest.raises(PerRequestAuthError):
+            request_auth._request_config("k")
+        with pytest.raises(PerRequestAuthError):
+            request_auth.get_connection()
+        with pytest.raises(PerRequestAuthError):
+            request_auth.get_access_controller()
+    finally:
+        request_auth._base_config = prev
+
+
+def test_get_connection_builds_once_per_request():
+    with _configured(), patch("mcp_server_odoo.request_auth.OdooConnection") as conn_cls:
+        conn = conn_cls.return_value
+        first = request_auth.get_connection()
+        second = request_auth.get_connection()
+        assert first is conn
+        assert second is conn  # memoized within the request
+        conn_cls.assert_called_once()
+        conn.connect.assert_called_once()
+        conn.authenticate.assert_called_once()
+
+
+def test_get_access_controller_builds_from_request_connection():
+    with (
+        _configured(),
+        patch("mcp_server_odoo.request_auth.OdooConnection") as conn_cls,
+        patch("mcp_server_odoo.request_auth.AccessController") as ac_cls,
+    ):
+        conn_cls.return_value.database = "cubert"
+        conn_cls.return_value.auth_method = "api_key"
+        first = request_auth.get_access_controller()
+        second = request_auth.get_access_controller()
+        assert first is ac_cls.return_value
+        assert second is first  # memoized within the request
+        ac_cls.assert_called_once()
+        assert ac_cls.call_args.kwargs["database"] == "cubert"
+        assert ac_cls.call_args.kwargs["auth_method"] == "api_key"
+
+
+def test_reset_disconnects_and_clears_request_state():
+    with _configured(), patch("mcp_server_odoo.request_auth.OdooConnection") as conn_cls:
+        conn = conn_cls.return_value
+        request_auth.get_connection()
+        request_auth.reset()
+        conn.disconnect.assert_called_once_with(suppress_logging=True)
+        # State cleared: the next access has no key and fails closed.
+        with pytest.raises(PerRequestAuthError):
+            request_auth.get_connection()
+
+
+def test_reset_swallows_disconnect_errors():
+    with _configured(), patch("mcp_server_odoo.request_auth.OdooConnection") as conn_cls:
+        conn_cls.return_value.disconnect.side_effect = RuntimeError("boom")
+        request_auth.get_connection()
+        request_auth.reset()  # cleanup must never raise
+
+
+def test_proxies_route_to_the_request_objects():
+    with (
+        _configured(),
+        patch("mcp_server_odoo.request_auth.OdooConnection") as conn_cls,
+        patch("mcp_server_odoo.request_auth.AccessController") as ac_cls,
+    ):
+        conn_cls.return_value.database = "cubert"
+        conn_cls.return_value.auth_method = "api_key"
+        conn_cls.return_value.is_authenticated = True
+        ac_cls.return_value.enabled_models = ["project.task"]
+        assert request_auth.connection_proxy().is_authenticated is True
+        assert request_auth.access_controller_proxy().enabled_models == ["project.task"]
+
+
+def test_middleware_ignores_non_http_scopes():
+    downstream = _Recorder()
+    mw = PerRequestAuthMiddleware(downstream)
+
+    async def go():
+        await mw({"type": "lifespan"}, None, None)
+
+    _run(go())
+    assert downstream.called is True  # passed through untouched

--- a/tests/test_per_request_auth.py
+++ b/tests/test_per_request_auth.py
@@ -1,0 +1,182 @@
+"""Unit tests for per-request authentication (ODOO_MCP_PER_REQUEST_AUTH).
+
+These run without a live Odoo: they cover the security-critical logic that a
+regression could silently break — header parsing, the 401 gate, contextvar
+reset (no key bleed across requests), fail-closed access, and the config
+contract. The live two-key isolation / interleaving / revocation behaviour is
+exercised separately against a real Odoo + cubert_mcp addon.
+"""
+
+import asyncio
+
+import pytest
+
+from mcp_server_odoo import request_auth
+from mcp_server_odoo.config import OdooConfig
+from mcp_server_odoo.request_auth import (
+    PerRequestAuthError,
+    PerRequestAuthMiddleware,
+    _extract_key,
+    current_api_key,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Header extraction
+# --------------------------------------------------------------------------- #
+def _headers(mapping=None):
+    """Build an ASGI raw-headers list from a {name: value} dict."""
+    mapping = mapping or {}
+    return [(k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in mapping.items()]
+
+
+def test_extract_bearer_key():
+    assert _extract_key(_headers({"Authorization": "Bearer abc123"})) == "abc123"
+
+
+def test_extract_bearer_case_insensitive_scheme():
+    assert _extract_key(_headers({"Authorization": "bearer abc123"})) == "abc123"
+
+
+def test_extract_x_api_key_fallback():
+    assert _extract_key(_headers({"X-API-Key": "k"})) == "k"
+
+
+def test_extract_missing_returns_none():
+    assert _extract_key(_headers()) is None
+
+
+def test_extract_malformed_authorization_returns_none():
+    assert _extract_key(_headers({"Authorization": "abc123"})) is None  # no scheme
+    assert _extract_key(_headers({"Authorization": "Bearer "})) is None  # empty token
+    assert _extract_key(_headers({"Authorization": "Basic abc123"})) is None  # wrong scheme
+
+
+# --------------------------------------------------------------------------- #
+# Config contract
+# --------------------------------------------------------------------------- #
+def _cfg(**kw):
+    base = dict(url="http://odoo:8069", transport="streamable-http",
+                database="cubert", per_request_auth=True)
+    base.update(kw)
+    return OdooConfig(**base)
+
+
+def test_per_request_uses_standard_endpoints():
+    ep = _cfg().get_endpoint_paths()
+    assert ep["object"] == "/xmlrpc/2/object"
+    assert ep["common"] == "/xmlrpc/2/common"
+
+
+def test_per_request_needs_no_startup_key():
+    # No api_key / username / password required at startup.
+    cfg = _cfg()
+    assert cfg.api_key is None
+
+
+def test_per_request_requires_database():
+    with pytest.raises(ValueError, match="ODOO_DB"):
+        _cfg(database=None)
+
+
+def test_per_request_requires_http_transport():
+    with pytest.raises(ValueError, match="streamable-http"):
+        _cfg(transport="stdio")
+
+
+def test_per_request_rejects_yolo():
+    with pytest.raises(ValueError, match="YOLO"):
+        _cfg(yolo_mode="true")
+
+
+def test_standard_mode_still_requires_auth():
+    # Regression: without per-request auth, a key or credentials are required.
+    with pytest.raises(ValueError, match="Authentication required"):
+        OdooConfig(url="http://odoo:8069")
+
+
+# --------------------------------------------------------------------------- #
+# Fail-closed access
+# --------------------------------------------------------------------------- #
+def test_get_connection_without_key_fails_closed():
+    request_auth.configure(_cfg(), performance_manager=object())
+    token = current_api_key.set(None)
+    try:
+        with pytest.raises(PerRequestAuthError):
+            request_auth.get_connection()
+    finally:
+        current_api_key.reset(token)
+
+
+# --------------------------------------------------------------------------- #
+# ASGI middleware: 401 gate + contextvar lifecycle
+# --------------------------------------------------------------------------- #
+class _Recorder:
+    """Fake downstream ASGI app that records the key visible mid-request."""
+
+    def __init__(self):
+        self.called = False
+        self.seen_key = "UNSET"
+
+    async def __call__(self, scope, receive, send):
+        self.called = True
+        self.seen_key = current_api_key.get()
+
+
+async def _send_collect(store):
+    async def send(msg):
+        store.append(msg)
+    return send
+
+
+def _scope(path="/mcp", headers=None):
+    return {"type": "http", "path": path, "headers": headers or []}
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_middleware_rejects_missing_key_with_401():
+    downstream = _Recorder()
+    mw = PerRequestAuthMiddleware(downstream)
+    sent = []
+
+    async def go():
+        send = await _send_collect(sent)
+        await mw(_scope(headers=_headers()), None, send)
+
+    _run(go())
+    assert downstream.called is False  # never dispatched
+    assert sent[0]["type"] == "http.response.start"
+    assert sent[0]["status"] == 401
+
+
+def test_middleware_sets_key_for_request_then_resets():
+    downstream = _Recorder()
+    mw = PerRequestAuthMiddleware(downstream)
+    sent = []
+
+    async def go():
+        send = await _send_collect(sent)
+        await mw(_scope(headers=_headers({"Authorization": "Bearer thekey"})), None, send)
+
+    _run(go())
+    assert downstream.called is True
+    assert downstream.seen_key == "thekey"  # visible during dispatch
+    # Reset in finally: no bleed to the next request on a reused task.
+    assert current_api_key.get() is None
+
+
+def test_middleware_passes_through_unguarded_path():
+    downstream = _Recorder()
+    mw = PerRequestAuthMiddleware(downstream, guarded_prefix="/mcp")
+    sent = []
+
+    async def go():
+        send = await _send_collect(sent)
+        await mw(_scope(path="/health", headers=_headers()), None, send)
+
+    _run(go())
+    assert downstream.called is True  # /health not gated
+    assert sent == []  # no 401 emitted

--- a/tests/test_per_request_auth.py
+++ b/tests/test_per_request_auth.py
@@ -56,8 +56,12 @@ def test_extract_malformed_authorization_returns_none():
 # Config contract
 # --------------------------------------------------------------------------- #
 def _cfg(**kw):
-    base = dict(url="http://odoo:8069", transport="streamable-http",
-                database="cubert", per_request_auth=True)
+    base = dict(
+        url="http://odoo:8069",
+        transport="streamable-http",
+        database="cubert",
+        per_request_auth=True,
+    )
     base.update(kw)
     return OdooConfig(**base)
 
@@ -126,6 +130,7 @@ class _Recorder:
 async def _send_collect(store):
     async def send(msg):
         store.append(msg)
+
     return send
 
 

--- a/tests/test_per_request_server.py
+++ b/tests/test_per_request_server.py
@@ -1,0 +1,115 @@
+"""Server wiring for per-request auth (ODOO_MCP_PER_REQUEST_AUTH).
+
+Covers the branches the per-request mode switches inside OdooMCPServer:
+proxy wiring at construction, the no-op startup/cleanup connection paths,
+the health payload, the exposure log variant, and the stateless transport
+configuration. No live Odoo involved.
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+from mcp_server_odoo import request_auth
+from mcp_server_odoo.config import OdooConfig
+from mcp_server_odoo.request_auth import PerRequestAuthMiddleware, _PerRequestProxy
+from mcp_server_odoo.server import OdooMCPServer
+
+
+def _cfg(**kw):
+    base = dict(
+        url="http://odoo:8069",
+        transport="streamable-http",
+        database="cubert",
+        per_request_auth=True,
+    )
+    base.update(kw)
+    return OdooConfig(**base)
+
+
+@pytest.fixture()
+def server():
+    prev_cfg = request_auth._base_config
+    prev_pm = request_auth._performance_manager
+    try:
+        yield OdooMCPServer(_cfg())
+    finally:
+        request_auth._base_config = prev_cfg
+        request_auth._performance_manager = prev_pm
+
+
+def test_setup_wires_proxies_and_configures_module(server):
+    assert isinstance(server.connection, _PerRequestProxy)
+    assert isinstance(server.access_controller, _PerRequestProxy)
+    # configure() ran with the server's config; handlers registered eagerly.
+    assert request_auth._base_config is server.config
+    assert server.performance_manager is not None
+
+
+def test_ensure_connection_is_a_noop(server):
+    # No server-wide connection is created at startup; the proxies stay.
+    server._ensure_connection()
+    assert isinstance(server.connection, _PerRequestProxy)
+
+
+def test_cleanup_connection_is_a_noop(server):
+    # Touching the proxy outside a request context would fail closed; the
+    # early return means cleanup never touches it.
+    server._cleanup_connection()
+
+
+def test_health_status_reports_per_request_mode(server):
+    health = server.get_health_status()
+    assert health["status"] == "healthy"
+    assert health["connection"]["mode"] == "per-request-auth"
+
+
+def test_warn_if_exposed_notes_the_401_gate(server, caplog):
+    with caplog.at_level(logging.INFO, logger="mcp_server_odoo.server"):
+        server._warn_if_exposed("0.0.0.0")
+    joined = " ".join(record.getMessage() for record in caplog.records)
+    assert "per-request auth" in joined
+    # The generic "no authentication" warning would be false here.
+    assert "NO built-in" not in joined
+
+
+def test_run_http_delegates_to_per_request_transport(server, monkeypatch):
+    called = {}
+
+    async def fake_run(host, port):
+        called["hostport"] = (host, port)
+
+    monkeypatch.setattr(server, "_run_http_per_request", fake_run)
+    asyncio.run(server.run_http(host="127.0.0.1", port=8069))
+    assert called["hostport"] == ("127.0.0.1", 8069)
+
+
+def test_run_http_per_request_serves_stateless_guarded_app(server, monkeypatch):
+    import uvicorn
+
+    captured = {}
+
+    class FakeConfig:
+        def __init__(self, app, host, port, log_level):
+            captured["app"] = app
+            captured["hostport"] = (host, port)
+            captured["log_level"] = log_level
+
+    class FakeServer:
+        def __init__(self, config):
+            captured["config"] = config
+
+        async def serve(self):
+            captured["served"] = True
+
+    monkeypatch.setattr(uvicorn, "Config", FakeConfig)
+    monkeypatch.setattr(uvicorn, "Server", FakeServer)
+    asyncio.run(server._run_http_per_request("127.0.0.1", 8069))
+
+    # Stateless + json so the middleware's contextvar reaches the handler.
+    assert server.app.settings.stateless_http is True
+    assert server.app.settings.json_response is True
+    assert isinstance(captured["app"], PerRequestAuthMiddleware)
+    assert captured["hostport"] == ("127.0.0.1", 8069)
+    assert captured["served"] is True


### PR DESCRIPTION
## Summary

Adds an opt-in `ODOO_MCP_PER_REQUEST_AUTH` mode for the `streamable-http`
transport, so a single MCP server can serve multiple users where each request
authenticates as its own Odoo user instead of everyone sharing one server-wide
`ODOO_API_KEY`.

## How it works

- Each HTTP request carries its own key in `Authorization: Bearer <api-key>`
  (`X-API-Key` is also accepted).
- A small ASGI middleware reads the header into a context variable, returns
  **HTTP 401** before dispatch when it is missing or malformed, and resets the
  context variable in a `finally` so no key leaks across requests on a reused
  worker task.
- The transport runs **stateless** in this mode so the per-request key set by
  the middleware is visible to the tool. With a stateful session the tool runs
  on a separate long-lived task that the per-request header never reaches.
- Access is resolved **per request** into a short-lived `OdooConnection` /
  `AccessController` built from that key, then torn down. There is no shared,
  server-wide connection in this mode (fail-closed): any Odoo access without a
  request key raises rather than silently falling back to a shared identity.
- The user id is resolved via the existing `/mcp/auth/validate` endpoint; data
  calls run over standard XML-RPC as that user, so Odoo's own access rights and
  record rules stay authoritative.

## Compatibility

- Default **off**. `stdio` and the existing standard / YOLO HTTP modes are
  unchanged.
- Config validation: the mode requires `streamable-http` and an explicit
  `ODOO_DB`, and is mutually exclusive with YOLO.

## Tests

Adds unit tests covering header parsing, the 401 gate, context-variable reset
(no cross-request key bleed), fail-closed access, and the config contract.

## Note

Bearer tokens are Odoo credentials. Deployments should terminate TLS in front
or keep the endpoint on a trusted network; the startup log states this for the
mode.
