### PR TITLE
Add ODOO_ALLOWED_COMPANIES for multi-company scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ The server requires the following environment variables:
 | `ODOO_PASSWORD` | Yes* | Password (if not using API key) | `admin` |
 | `ODOO_DB` | No | Database name (auto-detected if not set) | `mycompany` |
 | `ODOO_LOCALE` | No | Language/locale for Odoo responses | `es_ES`, `fr_FR`, `de_DE` |
+| `ODOO_ALLOWED_COMPANIES` | No | Comma-separated company IDs to scope all operations to (multi-company setups) | `1`, `1,3` |
 | `ODOO_YOLO` | No | YOLO mode - bypasses MCP security (⚠️ DEV ONLY) | `off`, `read`, `true` |
 | `ODOO_MCP_ENABLE_METHOD_CALLS` | No | Enable the `call_model_method` tool — requires `ODOO_YOLO=true` (⚠️ Dangerous, see [`call_model_method`](#call_model_method)) | `false`, `true` |
 
@@ -313,6 +314,36 @@ The server requires the following environment variables:
 - If database listing is restricted on your server, you must specify `ODOO_DB`
 - API key authentication is recommended for better security
 - The server also loads environment variables from a `.env` file in the working directory
+
+**Multi-company scoping (`ODOO_ALLOWED_COMPANIES`):**
+In multi-company databases, the authenticated user's default company applies to
+every record the server creates, and record visibility spans all of the user's
+allowed companies. Setting `ODOO_ALLOWED_COMPANIES` injects
+`allowed_company_ids` into the context of every RPC call, so record rules,
+`env.company`, and create defaults are limited to the listed companies. A useful
+pattern is configuring one MCP server entry per company, sharing a single Odoo
+user:
+
+```json
+{
+  "mcpServers": {
+    "odoo-company-a": {
+      "command": "uvx",
+      "args": ["mcp-server-odoo"],
+      "env": { "ODOO_URL": "...", "ODOO_API_KEY": "...", "ODOO_ALLOWED_COMPANIES": "1" }
+    },
+    "odoo-company-b": {
+      "command": "uvx",
+      "args": ["mcp-server-odoo"],
+      "env": { "ODOO_URL": "...", "ODOO_API_KEY": "...", "ODOO_ALLOWED_COMPANIES": "3" }
+    }
+  }
+}
+```
+
+Note this is context-level scoping, not a security boundary: the credentials can
+still access every company the Odoo user is allowed to. For hard isolation,
+restrict the user's allowed companies in Odoo itself.
 
 #### Advanced Configuration
 

--- a/mcp_server_odoo/config.py
+++ b/mcp_server_odoo/config.py
@@ -37,7 +37,7 @@ class OdooConfig:
 
     # Company scoping: comma-separated company IDs injected as
     # allowed_company_ids into every RPC context (record rules + defaults).
-    allowed_companies: Optional[list] = None
+    allowed_companies: Optional[list[int]] = None
 
     # MCP transport configuration
     transport: Literal["stdio", "streamable-http"] = "stdio"
@@ -243,14 +243,17 @@ def load_config(env_file: Optional[Path] = None) -> OdooConfig:
         except ValueError:
             raise ValueError(f"{key} must be a valid number") from None
 
-    def get_company_ids_env(key: str) -> Optional[list]:
+    def get_company_ids_env(key: str) -> Optional[list[int]]:
         value = os.getenv(key)
         if value is None or not value.strip():
             return None
         try:
-            return [int(c) for c in value.split(",") if c.strip()]
+            ids = [int(c) for c in value.split(",") if c.strip()]
         except ValueError:
             raise ValueError(f"{key} must be a comma-separated list of integer IDs") from None
+        # A value of only separators/whitespace (e.g. ",") parses to an empty
+        # list; treat it as unset so scoping is never half-configured.
+        return ids or None
 
     def get_bool_env(key: str, default: bool = False) -> bool:
         raw = os.getenv(key)

--- a/mcp_server_odoo/config.py
+++ b/mcp_server_odoo/config.py
@@ -35,6 +35,10 @@ class OdooConfig:
     max_smart_fields: int = 15
     locale: Optional[str] = None
 
+    # Company scoping: comma-separated company IDs injected as
+    # allowed_company_ids into every RPC context (record rules + defaults).
+    allowed_companies: Optional[list] = None
+
     # MCP transport configuration
     transport: Literal["stdio", "streamable-http"] = "stdio"
     host: str = "localhost"
@@ -239,6 +243,15 @@ def load_config(env_file: Optional[Path] = None) -> OdooConfig:
         except ValueError:
             raise ValueError(f"{key} must be a valid number") from None
 
+    def get_company_ids_env(key: str) -> Optional[list]:
+        value = os.getenv(key)
+        if value is None or not value.strip():
+            return None
+        try:
+            return [int(c) for c in value.split(",") if c.strip()]
+        except ValueError:
+            raise ValueError(f"{key} must be a comma-separated list of integer IDs") from None
+
     def get_bool_env(key: str, default: bool = False) -> bool:
         raw = os.getenv(key)
         if raw is None:
@@ -282,6 +295,7 @@ def load_config(env_file: Optional[Path] = None) -> OdooConfig:
         port=get_int_env("ODOO_MCP_PORT", 8000),
         session_idle_timeout=get_optional_float_env("ODOO_MCP_SESSION_IDLE_TIMEOUT"),
         locale=os.getenv("ODOO_LOCALE", "").strip() or None,
+        allowed_companies=get_company_ids_env("ODOO_ALLOWED_COMPANIES"),
         yolo_mode=get_yolo_mode(),
         enable_method_calls=get_bool_env("ODOO_MCP_ENABLE_METHOD_CALLS", False),
         allowed_hosts=parse_allowed_hosts(),

--- a/mcp_server_odoo/odoo_connection.py
+++ b/mcp_server_odoo/odoo_connection.py
@@ -958,7 +958,8 @@ class OdooConnection:
         if self.config.allowed_companies:
             if "context" not in kwargs:
                 kwargs["context"] = {}
-            kwargs["context"]["allowed_company_ids"] = self.config.allowed_companies
+            # Copy so callers mutating the context cannot alter the config.
+            kwargs["context"]["allowed_company_ids"] = list(self.config.allowed_companies)
 
         try:
             # Log the operation (values redacted — write payloads can carry

--- a/mcp_server_odoo/odoo_connection.py
+++ b/mcp_server_odoo/odoo_connection.py
@@ -952,6 +952,14 @@ class OdooConnection:
                 kwargs["context"] = {}
             kwargs["context"].setdefault("lang", self.config.locale)
 
+        # Company scoping (patch): force allowed_company_ids on every call so
+        # record rules and company defaults are limited to the configured
+        # companies. Deliberately overrides any caller-provided value.
+        if self.config.allowed_companies:
+            if "context" not in kwargs:
+                kwargs["context"] = {}
+            kwargs["context"]["allowed_company_ids"] = self.config.allowed_companies
+
         try:
             # Log the operation (values redacted — write payloads can carry
             # passwords/PII that must not land in log files)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -139,6 +139,19 @@ class TestLoadConfig:
         monkeypatch.setenv("ODOO_ALLOWED_COMPANIES", "")
         assert load_config().allowed_companies is None
 
+        # Only separators/whitespace parses to nothing usable -> unset
+        monkeypatch.setenv("ODOO_ALLOWED_COMPANIES", " , ")
+        assert load_config().allowed_companies is None
+
+    def test_load_config_allowed_companies_invalid(self, monkeypatch):
+        """Non-integer entries in ODOO_ALLOWED_COMPANIES are rejected."""
+        monkeypatch.setenv("ODOO_URL", "http://test.odoo.com")
+        monkeypatch.setenv("ODOO_API_KEY", "env-api-key")
+        monkeypatch.setenv("ODOO_ALLOWED_COMPANIES", "1,main")
+
+        with pytest.raises(ValueError, match="comma-separated list of integer IDs"):
+            load_config()
+
     def test_load_config_from_env_file(self, monkeypatch):
         """Test loading configuration from .env file."""
         # Clear environment variables

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -118,6 +118,27 @@ class TestLoadConfig:
         assert config.default_limit == 20
         assert config.max_limit == 200
 
+    def test_load_config_allowed_companies(self, monkeypatch):
+        """Test parsing of ODOO_ALLOWED_COMPANIES into a list of ints."""
+        monkeypatch.setenv("ODOO_URL", "http://test.odoo.com")
+        monkeypatch.setenv("ODOO_API_KEY", "env-api-key")
+        monkeypatch.setenv("ODOO_ALLOWED_COMPANIES", "1, 4")
+
+        config = load_config()
+
+        assert config.allowed_companies == [1, 4]
+
+    def test_load_config_allowed_companies_unset(self, monkeypatch):
+        """ODOO_ALLOWED_COMPANIES absent or empty means no company scoping."""
+        monkeypatch.setenv("ODOO_URL", "http://test.odoo.com")
+        monkeypatch.setenv("ODOO_API_KEY", "env-api-key")
+        monkeypatch.delenv("ODOO_ALLOWED_COMPANIES", raising=False)
+
+        assert load_config().allowed_companies is None
+
+        monkeypatch.setenv("ODOO_ALLOWED_COMPANIES", "")
+        assert load_config().allowed_companies is None
+
     def test_load_config_from_env_file(self, monkeypatch):
         """Test loading configuration from .env file."""
         # Clear environment variables

--- a/tests/test_odoo_connection_crud.py
+++ b/tests/test_odoo_connection_crud.py
@@ -351,6 +351,41 @@ class TestExecuteKwErrorHandling:
         kwargs = conn._object_proxy.execute_kw.call_args[0][6]
         assert kwargs["context"]["lang"] == "de_DE"
 
+    def test_allowed_companies_injection(self, connected_connection):
+        """execute_kw should inject allowed_company_ids into context when configured."""
+        conn = connected_connection
+        conn.config.allowed_companies = [1, 3]
+        conn._object_proxy.execute_kw.return_value = []
+
+        conn.search("res.partner", [])
+
+        kwargs = conn._object_proxy.execute_kw.call_args[0][6]
+        assert kwargs["context"]["allowed_company_ids"] == [1, 3]
+
+    def test_allowed_companies_overrides_caller_context(self, connected_connection):
+        """Company scoping is a guardrail: caller-provided values must not widen it."""
+        conn = connected_connection
+        conn.config.allowed_companies = [1]
+        conn._object_proxy.execute_kw.return_value = []
+
+        conn.execute_kw(
+            "res.partner", "search", [[]], {"context": {"allowed_company_ids": [1, 2, 3]}}
+        )
+
+        kwargs = conn._object_proxy.execute_kw.call_args[0][6]
+        assert kwargs["context"]["allowed_company_ids"] == [1]
+
+    def test_allowed_companies_not_injected_when_unset(self, connected_connection):
+        """Without configuration, context must not carry allowed_company_ids."""
+        conn = connected_connection
+        conn.config.allowed_companies = None
+        conn._object_proxy.execute_kw.return_value = []
+
+        conn.search("res.partner", [])
+
+        kwargs = conn._object_proxy.execute_kw.call_args[0][6]
+        assert "allowed_company_ids" not in kwargs.get("context", {})
+
     def test_marshal_none_fault_returns_none(self, connected_connection):
         """Odoo's "cannot marshal None" fault is translated to a None return.
 

--- a/tests/test_odoo_connection_crud.py
+++ b/tests/test_odoo_connection_crud.py
@@ -375,6 +375,18 @@ class TestExecuteKwErrorHandling:
         kwargs = conn._object_proxy.execute_kw.call_args[0][6]
         assert kwargs["context"]["allowed_company_ids"] == [1]
 
+    def test_allowed_companies_context_is_copied(self, connected_connection):
+        """Mutating the injected context must not corrupt the shared config."""
+        conn = connected_connection
+        conn.config.allowed_companies = [1, 3]
+        conn._object_proxy.execute_kw.return_value = []
+
+        conn.search("res.partner", [])
+
+        kwargs = conn._object_proxy.execute_kw.call_args[0][6]
+        kwargs["context"]["allowed_company_ids"].append(99)
+        assert conn.config.allowed_companies == [1, 3]
+
     def test_allowed_companies_not_injected_when_unset(self, connected_connection):
         """Without configuration, context must not carry allowed_company_ids."""
         conn = connected_connection


### PR DESCRIPTION
## Problem

In multi-company databases, every create lands in the authenticated user's **default company**, and reads span **all** of the user's allowed companies. Working through MCP on company A, it is easy to silently create documents in company B — wrong company, wrong currency — without the client noticing (this is how we found it: a purchase order intended for our Cambodian entity was created under our Singapore entity in SGD).

## Solution

New optional env var `ODOO_ALLOWED_COMPANIES` — a comma-separated list of company IDs. When set, `allowed_company_ids` is injected into the context of every `execute_kw` call:

- record rules hide other companies' records (reads, searches, counts)
- `env.company` resolves to the first listed company, so create defaults (company, currency, journals) are correct
- caller-provided context cannot widen the scope — the configured value always wins, since the setting is meant as a guardrail

When unset, behavior is unchanged.

## Use case

One MCP server entry per company, sharing a single Odoo user (no extra user license needed):

```json
{
  "mcpServers": {
    "odoo-company-a": { "env": { "ODOO_ALLOWED_COMPANIES": "1" } },
    "odoo-company-b": { "env": { "ODOO_ALLOWED_COMPANIES": "3" } }
  }
}
```

Documented in the README, including an explicit note that this is context-level scoping, not a security boundary (the credentials can still access every company the Odoo user is allowed to; hard isolation requires restricting the user's allowed companies in Odoo).

## Testing

- 5 new unit tests: env parsing (valid / unset / empty), context injection, override-of-caller-context, no-injection-when-unset
- Full suite: 693 passed, ruff clean
- Verified against a live Odoo 19 multi-company database: with scoping to company A, company B's `account.move` records return 0 results and B's purchase orders are not found, and vice versa