### PR TITLE
fix: type domain and fields parameters instead of Any

### DIFF
--- a/mcp_server_odoo/tools.py
+++ b/mcp_server_odoo/tools.py
@@ -12,10 +12,11 @@ import re
 import xmlrpc.client
 from ast import literal_eval as _parse_python_literal
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional, Sequence, Set, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union
 
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
+from pydantic import BeforeValidator
 
 from .access_control import (
     AccessControlError,
@@ -317,6 +318,61 @@ def _validate_offset(offset: int, limit: int) -> None:
             f"limit {limit} — narrow the domain or use 'order' to bring "
             "the target records into earlier pages"
         )
+
+
+# --- Domain typing -----------------------------------------------------------
+# An Odoo domain is a flat list mixing condition triplets with logical operator
+# strings, e.g. ["|", ["name", "ilike", "acme"], ["is_company", "=", True]].
+#
+# Why the explicit Tuple: a bare List[Any] serializes to {"items": {}} — a
+# free-form JSON Schema. Clients that constrain generation with a grammar
+# (llama.cpp and friends, i.e. every local model) then get NO structural signal
+# and happily emit `domain="name = acme"`, which only fails server-side. Typing
+# the triplet emits prefixItems, so the malformed call becomes unrepresentable
+# rather than merely wrong. Small models cannot recover from a type error they
+# were never prevented from making.
+#
+# The condition's VALUE position needs the same treatment. `Any` there still
+# serializes to a bare `{}` — llama.cpp's schema→GBNF converter turns a
+# constraint-free `{}` into a free-form OBJECT rule (not "anything"), so the
+# sampler literally cannot emit a string/int/bool there. Observed live:
+# `[["model", "=", {}]]` instead of `[["model", "=", "res.partner"]]`. Bound
+# it to the concrete Odoo value types instead — bool must precede int so
+# pydantic doesn't coerce True/False into 1/0.
+DomainValue = Union[bool, int, float, str, List[Union[bool, int, float, str]]]
+DomainCondition = Tuple[str, str, DomainValue]
+DomainElement = Union[DomainCondition, str]  # str covers "&", "|", "!"
+
+
+def _coerce_domain_string(value: Any) -> Any:
+    """Accept the legacy '[["name","ilike","acme"]]' string form at runtime.
+
+    Kept as a BeforeValidator rather than a `str` branch in the annotation so
+    the published JSON Schema advertises ONLY the list form. A visible string
+    branch is an escape hatch a weak model will take — it emitted
+    domain="name ilike 'inno'" and burned turns on the rejection — while the
+    clients that legitimately send stringified JSON still work here.
+    """
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            try:
+                return _parse_python_literal(value)
+            except (ValueError, SyntaxError):
+                raise ValueError(
+                    f"Invalid domain parameter. Expected a list of "
+                    f'["field", "operator", value] conditions, e.g. {_DOMAIN_EXAMPLE} — '
+                    f"got: {value[:100]}"
+                ) from None
+    return value
+
+
+DomainInput = Annotated[Optional[List[DomainElement]], BeforeValidator(_coerce_domain_string)]
+
+# Shown in error messages: small models copy a concrete example, they cannot
+# infer one from a type name.
+_DOMAIN_EXAMPLE = '[["name", "ilike", "acme"]]'
 
 
 def _json_safe(value: Any) -> Any:
@@ -827,8 +883,18 @@ class OdooToolHandler:
         if domain is None:
             return []
         if not isinstance(domain, str):
-            if not isinstance(domain, list):
-                raise ValidationError(f"Domain must be a list, got {type(domain).__name__}")
+            if not isinstance(domain, (list, tuple)):
+                raise ValidationError(
+                    f"Domain must be a list, got {type(domain).__name__}. "
+                    f"Example: {_DOMAIN_EXAMPLE}"
+                )
+            # Pydantic coerces the typed triplets to tuples; left as-is rather
+            # than normalized to lists — XML-RPC marshals both identically,
+            # Odoo's own domain literals are conventionally tuples, and
+            # normalizing here would rebuild every caller-supplied domain
+            # (including ones already carrying tuples on purpose, e.g. the
+            # ir.attachment scope appended below) just to change a type that
+            # doesn't matter downstream.
             # Same guard the write paths use: an oversized int anywhere in the
             # domain would raise OverflowError mid-marshal and surface as a
             # transport-flavoured "Connection error", which is exactly the
@@ -853,12 +919,15 @@ class OdooToolHandler:
                 parsed = _parse_python_literal(domain)
             except (ValueError, SyntaxError, RecursionError):
                 raise ValidationError(
-                    f"Invalid domain parameter. Expected JSON array or Python list, "
-                    f"got: {domain[:100]}..."
+                    f"Invalid domain parameter. Expected a list of "
+                    f'["field", "operator", value] conditions, e.g. {_DOMAIN_EXAMPLE} — '
+                    f"got: {domain[:100]}"
                 ) from e
 
         if not isinstance(parsed, list):
-            raise ValidationError(f"Domain must be a list, got {type(parsed).__name__}")
+            raise ValidationError(
+                f"Domain must be a list, got {type(parsed).__name__}. Example: {_DOMAIN_EXAMPLE}"
+            )
         _check_xmlrpc_int_bounds(parsed, "domain")
         check_domain_balance(parsed)
 
@@ -895,8 +964,12 @@ class OdooToolHandler:
         )
         async def search_records(
             model: str,
-            domain: Optional[Any] = None,
-            fields: Optional[Any] = None,
+            # Explicitly typed rather than Any: Any serializes to an empty JSON
+            # Schema ({}), which grammar-constrained clients read as a free-form
+            # object, leaving the model unable to emit a list here. The runtime
+            # already accepts both forms (see _parse_domain_input).
+            domain: DomainInput = None,
+            fields: Optional[Union[List[str], str]] = None,
             limit: Optional[int] = None,
             offset: int = 0,
             order: Optional[str] = None,
@@ -910,6 +983,12 @@ class OdooToolHandler:
                     - A list: [['is_company', '=', True]]
                     - A JSON string: "[['is_company', '=', true]]"
                     - None: returns all records (default)
+                    Operators: use 'ilike' for case-insensitive substring
+                    match - Odoo adds the wildcards itself, so write
+                    ['name', 'ilike', 'acme'] and NEVER '%acme%'. 'like' is
+                    case-sensitive and matches the literal string. Conditions
+                    are ANDed by default; for OR put '|' BEFORE the two it
+                    joins: ['|', ['name', 'ilike', 'a'], ['ref', '=', 'b']].
                 fields: Field selection options - can be:
                     - None (default): Returns smart selection of common fields
                     - A list: ["field1", "field2", ...] - Returns only specified fields
@@ -1231,7 +1310,9 @@ class OdooToolHandler:
             model: str,
             groupby: Optional[List[str]] = None,
             aggregates: Optional[List[str]] = None,
-            domain: Optional[Any] = None,
+            # Explicitly typed, not Any: see search_records (empty schema breaks
+            # grammar-constrained clients).
+            domain: DomainInput = None,
             order: Optional[str] = None,
             limit: Optional[int] = None,
             offset: int = 0,
@@ -1265,6 +1346,9 @@ class OdooToolHandler:
                     group carries a count. Pass ``["__count", "amount_total:sum"]``
                     to get both.
                 domain: Odoo domain filter — list, JSON string, or None.
+                    Use 'ilike' for case-insensitive substring match
+                    (no '%' wildcards — Odoo adds them). OR is written
+                    as '|' BEFORE the two conditions it joins.
                 order: Sort expression over groupby keys / aggregates,
                     e.g. ``"date_order:month"`` or ``"amount_total:sum desc"``.
                 limit: Maximum number of groups. Defaults to

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,5 +1,6 @@
 """Test suite for MCP tools functionality."""
 
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -3696,6 +3697,131 @@ class TestParseDomainInput:
         with pytest.raises(ValidationError) as exc_info:
             handler._parse_domain_input([token, ["id", ">", 0]])
         assert "Invalid domain term" in str(exc_info.value)
+
+
+class TestToolSchemaTypes:
+    """Published tool schemas must be typed, never free-form.
+
+    A parameter annotated ``Any`` serializes to an empty JSON Schema (``{}``),
+    which means "anything". Clients that constrain generation from the schema
+    (llama.cpp compiles tool schemas to a GBNF grammar) treat a constraint-free
+    schema as a free-form *object*, so the model becomes unable to emit ``[``
+    for that parameter -- it sends ``{"search": "[[...]]"}`` instead of a domain
+    and retries forever. Keep every published parameter explicitly typed.
+    """
+
+    @pytest.fixture
+    def schemas(self):
+        app = FastMCP("test")
+        connection = MagicMock(spec=OdooConnection)
+        connection.is_authenticated = True
+        config = OdooConfig(url="http://localhost:8069", api_key="k", database="d")
+        OdooToolHandler(app, connection, MagicMock(spec=AccessController), config)
+
+        async def collect():
+            return {t.name: t.inputSchema for t in await app.list_tools()}
+
+        return asyncio.run(collect())
+
+    @staticmethod
+    def _admits_anything(param_schema: dict) -> bool:
+        """True if the schema places no constraint (bare {} or {} inside anyOf)."""
+        if param_schema == {}:
+            return True
+        return any(branch == {} for branch in param_schema.get("anyOf", []))
+
+    @staticmethod
+    def _find_bare_object(node) -> bool:
+        """True if a bare, constraint-free ``{}`` appears anywhere under `node`.
+
+        Recurses through the whole schema tree, not just its top-level
+        properties: a leaf position nested inside an already-typed container
+        (e.g. the value slot of a domain condition triplet) serializes to
+        ``{}`` just as readily as an untyped top-level parameter, and a
+        grammar-constrained client is equally unable to emit anything but an
+        object there.
+        """
+        if node == {}:
+            return True
+        if isinstance(node, dict):
+            return any(
+                TestToolSchemaTypes._find_bare_object(v)
+                for v in node.values()
+                if isinstance(v, (dict, list))
+            )
+        if isinstance(node, list):
+            return any(TestToolSchemaTypes._find_bare_object(v) for v in node)
+        return False
+
+    def test_no_parameter_is_constraint_free(self, schemas):
+        offenders = [
+            f"{tool}.{param}"
+            for tool, schema in schemas.items()
+            for param, param_schema in schema.get("properties", {}).items()
+            if self._admits_anything(param_schema)
+        ]
+        assert not offenders, f"Untyped (free-form) tool parameters: {offenders}"
+
+    @pytest.mark.parametrize(
+        "tool,param", [("search_records", "domain"), ("aggregate_records", "domain")]
+    )
+    def test_domain_schema_has_no_bare_object_anywhere(self, schemas, tool, param):
+        """Regression test: the condition triplet's VALUE slot was typed ``Any``,
+
+        which serialized to a bare ``{}`` nested inside the already-typed
+        triplet array. llama.cpp's grammar converter reads that as a
+        free-form object, so a grammar-constrained model could not emit a
+        string/int/bool there -- observed live emitting
+        ``[["model", "=", {}]]`` instead of
+        ``[["model", "=", "res.partner"]]``.
+        """
+        domain_schema = schemas[tool]["properties"][param]
+        assert not self._find_bare_object(domain_schema), (
+            f"{tool}.{param} schema still contains a bare {{}} somewhere in its tree"
+        )
+
+    @pytest.mark.parametrize(
+        "tool,param", [("search_records", "domain"), ("aggregate_records", "domain")]
+    )
+    def test_domain_schema_publishes_list_form_only(self, schemas, tool, param):
+        """The schema advertises the list form; the string form stays runtime-only.
+
+        A visible ``string`` branch is an escape hatch a grammar-constrained
+        model will take -- observed emitting ``domain="name ilike 'inno'"`` and
+        burning turns on the rejection. Strings are still accepted at runtime
+        via BeforeValidator (see test_domain_string_still_accepted_at_runtime),
+        so legacy clients keep working; they are just no longer advertised.
+        """
+        branches = schemas[tool]["properties"][param]["anyOf"]
+        types = {b.get("type") for b in branches}
+        assert "array" in types and "null" in types
+        assert "string" not in types
+
+    @pytest.mark.parametrize(
+        "tool,param", [("search_records", "domain"), ("aggregate_records", "domain")]
+    )
+    def test_domain_condition_triplet_is_shaped(self, schemas, tool, param):
+        """Each condition must be a 3-element ["field", "operator", value]."""
+        array_branch = next(
+            b for b in schemas[tool]["properties"][param]["anyOf"] if b.get("type") == "array"
+        )
+        cond = next(b for b in array_branch["items"]["anyOf"] if b.get("type") == "array")
+        assert cond["minItems"] == 3 and cond["maxItems"] == 3
+        assert [p.get("type") for p in cond["prefixItems"][:2]] == ["string", "string"]
+
+    def test_domain_string_still_accepted_at_runtime(self):
+        """Legacy stringified-JSON domains keep working despite the hidden branch."""
+        from mcp_server_odoo.tools import _coerce_domain_string
+
+        assert _coerce_domain_string('[["name","ilike","acme"]]') == [["name", "ilike", "acme"]]
+        assert _coerce_domain_string("[['name','ilike','acme']]") == [["name", "ilike", "acme"]]
+        assert _coerce_domain_string([["name", "ilike", "acme"]]) == [["name", "ilike", "acme"]]
+        with pytest.raises(ValueError, match=r'\["field", "operator", value\]'):
+            _coerce_domain_string("name = acme")
+
+    def test_fields_accepts_array_or_string(self, schemas):
+        branches = schemas["search_records"]["properties"]["fields"]["anyOf"]
+        assert {"array", "string", "null"} <= {b.get("type") for b in branches}
 
 
 class TestCallModelMethodTool:


### PR DESCRIPTION
## Problem

`search_records` and `aggregate_records` annotate `domain` (and `fields`) as `Optional[Any]`, which FastMCP serializes to an empty JSON Schema:

```json
"domain": { "anyOf": [ {}, {"type": "null"} ], "default": null }
```

An empty schema means "anything". Clients that only *validate* are fine, but clients that **constrain generation from the schema** are not. llama.cpp compiles tool schemas into a GBNF grammar, and its converter turns a constraint-free schema into a free-form **object** rule. The sampler then physically cannot emit `[` for that parameter, so a local model sends

```json
{"model": "crm.lead", "domain": {"search": "[['partner_name','ilike','HLM']]"}}
```

fails validation, narrates "domain needs to be a list", and retries the identical malformed shape forever. Besides an object, the only reachable value is `null`; there is no prompt-level workaround.

Reproduced at `temperature 0` against a llama.cpp server, with a prompt explicitly instructing the model to pass a list:

| `domain` schema | emitted arguments |
| --- | --- |
| `anyOf: [{}, null]` (current) | `{"domain": {"domain": ["partner_name","ilike","HLM"]}}` |
| `anyOf: [array, string, null]` | `{"domain": [["partner_name","ilike","HLM"]]}` |

Same model, same prompt, same decoding parameters. The schema decides the shape.

## Change

Annotate the parameters as what the runtime already accepts:

```python
domain: Optional[Union[List[Any], str]] = None
fields: Optional[Union[List[str], str]] = None
```

`_parse_domain_input` already handles a list *or* a JSON string, and the docstrings already document both forms plus `["__all__"]` for fields, so this only makes the published schema honest about the existing contract. No runtime behaviour changes, and no change for clients that already send lists.

After the fix the same model emits `"domain": [["partner_name","ilike","%hotel%"]]` and completes in two turns.

## Tests

`TestToolSchemaTypes` builds a real `FastMCP` app, registers the tools, and asserts:

- no published parameter is constraint-free (bare `{}` or `{}` inside an `anyOf`) — this one guards every tool, so a future parameter annotated `Any` fails here;
- `search_records.domain`, `aggregate_records.domain` and `search_records.fields` advertise `array`, `string` and `null`.

Verified the general check actually bites: reverting the annotation to `Optional[Any]` fails 3 tests; restoring it passes. Full `tests/test_tools.py` is green (159 passed), as are `ruff check`, `ruff format --check` and `ty check`.
